### PR TITLE
Feature/optional crm apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ansible/production_vars.yml
 /ansible/production_vars.yml
 /ansible/dev_vars.yml
 /.artifacts/
+/.ai/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ flowchart TD
     Argo --> LocalK3s[Local k3s Cluster<br/>Home / Lab / Internal Tools]
     Argo --> VPSK3s[VPS k3s Cluster<br/>Public Apps / Edge Services]
 
-    LocalK3s --> Apps1[Internal Apps<br/>Leantime, WiseMapping, Auth]
+    LocalK3s --> Apps1[Internal Apps<br/>Leantime, WiseMapping, Baserow, Auth]
     VPSK3s --> Apps2[Public Apps<br/>Websites, APIs, Client Services]
 
     Cloudflare[Cloudflare Tunnel / DNS] --> LocalK3s
@@ -180,6 +180,7 @@ This assumes a fresh Ubuntu/Debian host and no existing infrastructure.
    - `auth.thekeepstudios.com`
    - `projects.thekeepstudios.com`
    - `mindmaps.thekeepstudios.com`
+   - `relationships.thekeepstudios.com`
    - `grafana.thekeepstudios.com`
    - `prometheus.thekeepstudios.com`
    - `alerts.thekeepstudios.com`

--- a/ansible/dev_vars.yml.example
+++ b/ansible/dev_vars.yml.example
@@ -7,6 +7,10 @@
 #   wisemapping  Run static checks, create/reuse k3d, and smoke-test WiseMapping.
 #   leantime     Run static checks, create/reuse k3d, and smoke-test Leantime.
 #   baserow      Run static checks, create/reuse k3d, and smoke-test Baserow.
+#   twenty       Run static checks, create/reuse k3d, and smoke-test Twenty.
+#   espocrm      Run static checks, create/reuse k3d, and smoke-test EspoCRM.
+#   optional-crm Run static checks, create/reuse k3d, and smoke-test both optional CRM candidates.
+#   crm-bakeoff  Compatibility alias for optional-crm.
 #   platform     Run static checks, create/reuse k3d, and smoke-test local app targets.
 local_dev_profile: platform
 
@@ -39,3 +43,7 @@ local_dev_leantime_probe_host: projects.thekeepstudios.com
 local_dev_leantime_wait_timeout: 10m
 local_dev_baserow_probe_host: relationships.thekeepstudios.com
 local_dev_baserow_wait_timeout: 15m
+local_dev_twenty_probe_host: twenty.thekeepstudios.com
+local_dev_twenty_wait_timeout: 20m
+local_dev_espocrm_probe_host: espocrm.thekeepstudios.com
+local_dev_espocrm_wait_timeout: 20m

--- a/ansible/dev_vars.yml.example
+++ b/ansible/dev_vars.yml.example
@@ -6,6 +6,7 @@
 #   static       Run local static IaC checks only.
 #   wisemapping  Run static checks, create/reuse k3d, and smoke-test WiseMapping.
 #   leantime     Run static checks, create/reuse k3d, and smoke-test Leantime.
+#   baserow      Run static checks, create/reuse k3d, and smoke-test Baserow.
 #   platform     Run static checks, create/reuse k3d, and smoke-test local app targets.
 local_dev_profile: platform
 
@@ -36,3 +37,5 @@ local_dev_wisemapping_probe_host: mindmaps.thekeepstudios.com
 local_dev_wisemapping_wait_timeout: 10m
 local_dev_leantime_probe_host: projects.thekeepstudios.com
 local_dev_leantime_wait_timeout: 10m
+local_dev_baserow_probe_host: relationships.thekeepstudios.com
+local_dev_baserow_wait_timeout: 15m

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -55,6 +55,13 @@ platform_email:
   wisemapping:
     use_smtp: false
 
+# Optional CRM apps. Baserow remains the core relationship-management app.
+platform_optional_apps:
+  twenty:
+    enabled: false
+  espocrm:
+    enabled: false
+
 platform_validation_argo_app_status_retries: 60
 platform_validation_argo_app_status_delay: 10
 platform_validation_argo_app_allowed_statuses:

--- a/ansible/production_vars.yml.example
+++ b/ansible/production_vars.yml.example
@@ -19,6 +19,22 @@ platform_secrets:
   monitoring_basic_auth_user: "admin"
   monitoring_basic_auth_password: "CHANGE_ME"
 
+  # Optional CRM app secrets. Required only when the matching optional app is
+  # enabled below.
+  twenty_pg_database_password: "CHANGE_ME"
+  twenty_encryption_key: "CHANGE_ME"
+  twenty_app_secret: "CHANGE_ME"
+  espocrm_db_root_password: "CHANGE_ME"
+  espocrm_db_password: "CHANGE_ME"
+  espocrm_admin_password: "CHANGE_ME"
+
+# Optional CRM app toggles. Baserow remains the core relationship-management app.
+# platform_optional_apps:
+#   twenty:
+#     enabled: false
+#   espocrm:
+#     enabled: false
+
 # Optional: enable these only when gitops_repo_private is true.
 # gitops_repo_ssh_private_key_path: "/path/to/argocd-readonly-key"
 # gitops_repo_ssh_private_key: |

--- a/ansible/production_vars.yml.example
+++ b/ansible/production_vars.yml.example
@@ -51,6 +51,19 @@ platform_secrets:
 #     smtp_auth: true
 #     smtp_username: "postmaster@mg.thekeepstudios.com"
 #     smtp_password: "CHANGE_ME_MAILGUN_SMTP_PASSWORD"
+
+# Production validation checks that public HTTPS is available and direct HTTP
+# origins are not serving apps. Include the direct origin IP or hostnames for
+# every public app host you expose through Cloudflare.
+# direct_http_urls:
+#   - "http://auth.thekeepstudios.com"
+#   - "http://projects.thekeepstudios.com"
+#   - "http://mindmaps.thekeepstudios.com"
+#   - "http://relationships.thekeepstudios.com"
+#   - "http://grafana.thekeepstudios.com"
+#   - "http://prometheus.thekeepstudios.com"
+#   - "http://alerts.thekeepstudios.com"
+#   - "http://argocd.thekeepstudios.com"
 #     smtp_auto_tls: true
 #     smtp_secure: "STARTTLS"
 #     smtp_ssl_noverify: false

--- a/ansible/roles/dev_workstation/tasks/main.yml
+++ b/ansible/roles/dev_workstation/tasks/main.yml
@@ -6,8 +6,8 @@
 - name: Validate local development profile
   ansible.builtin.assert:
     that:
-      - local_dev_effective_profile in ['static', 'wisemapping', 'leantime', 'platform']
-    fail_msg: "local_dev_profile must be one of: static, wisemapping, leantime, platform."
+      - local_dev_effective_profile in ['static', 'wisemapping', 'leantime', 'baserow', 'platform']
+    fail_msg: "local_dev_profile must be one of: static, wisemapping, leantime, baserow, platform."
   tags: [always]
 
 - name: Apply local development profile defaults
@@ -175,6 +175,8 @@
     WISEMAPPING_WAIT_TIMEOUT: "{{ local_dev_wisemapping_wait_timeout | default('10m') }}"
     LEANTIME_PROBE_HOST: "{{ local_dev_leantime_probe_host | default('projects.thekeepstudios.com') }}"
     LEANTIME_WAIT_TIMEOUT: "{{ local_dev_leantime_wait_timeout | default('10m') }}"
+    BASEROW_PROBE_HOST: "{{ local_dev_baserow_probe_host | default('relationships.thekeepstudios.com') }}"
+    BASEROW_WAIT_TIMEOUT: "{{ local_dev_baserow_wait_timeout | default('15m') }}"
     DEV_MIN_FREE_GIB: "{{ local_dev_min_free_gib | default('80') }}"
     DEV_MIN_FREE_PERCENT: "{{ local_dev_min_free_percent | default('8') }}"
     DEV_SKIP_DISK_PREFLIGHT: "{{ (local_dev_skip_disk_preflight | default(false) | bool) | string | lower }}"

--- a/ansible/roles/dev_workstation/tasks/main.yml
+++ b/ansible/roles/dev_workstation/tasks/main.yml
@@ -6,8 +6,8 @@
 - name: Validate local development profile
   ansible.builtin.assert:
     that:
-      - local_dev_effective_profile in ['static', 'wisemapping', 'leantime', 'baserow', 'platform']
-    fail_msg: "local_dev_profile must be one of: static, wisemapping, leantime, baserow, platform."
+      - local_dev_effective_profile in ['static', 'wisemapping', 'leantime', 'baserow', 'twenty', 'espocrm', 'optional-crm', 'crm-bakeoff', 'platform']
+    fail_msg: "local_dev_profile must be one of: static, wisemapping, leantime, baserow, twenty, espocrm, optional-crm, crm-bakeoff, platform."
   tags: [always]
 
 - name: Apply local development profile defaults
@@ -177,6 +177,10 @@
     LEANTIME_WAIT_TIMEOUT: "{{ local_dev_leantime_wait_timeout | default('10m') }}"
     BASEROW_PROBE_HOST: "{{ local_dev_baserow_probe_host | default('relationships.thekeepstudios.com') }}"
     BASEROW_WAIT_TIMEOUT: "{{ local_dev_baserow_wait_timeout | default('15m') }}"
+    TWENTY_PROBE_HOST: "{{ local_dev_twenty_probe_host | default('twenty.thekeepstudios.com') }}"
+    TWENTY_WAIT_TIMEOUT: "{{ local_dev_twenty_wait_timeout | default('20m') }}"
+    ESPOCRM_PROBE_HOST: "{{ local_dev_espocrm_probe_host | default('espocrm.thekeepstudios.com') }}"
+    ESPOCRM_WAIT_TIMEOUT: "{{ local_dev_espocrm_wait_timeout | default('20m') }}"
     DEV_MIN_FREE_GIB: "{{ local_dev_min_free_gib | default('80') }}"
     DEV_MIN_FREE_PERCENT: "{{ local_dev_min_free_percent | default('8') }}"
     DEV_SKIP_DISK_PREFLIGHT: "{{ (local_dev_skip_disk_preflight | default(false) | bool) | string | lower }}"

--- a/ansible/roles/platform_gitops/tasks/main.yml
+++ b/ansible/roles/platform_gitops/tasks/main.yml
@@ -244,6 +244,33 @@
     ('created' in namespace_apply.stdout or 'configured' in namespace_apply.stdout)
   register: namespace_apply
 
+- name: Ensure optional app namespaces exist
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - apply
+      - -f
+      - "-"
+  args:
+    stdin: |
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: {{ item.name }}
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  loop:
+    - name: twenty
+      enabled: "{{ ((platform_optional_apps | default({})).twenty | default({})).enabled | default(false) | bool }}"
+    - name: espocrm
+      enabled: "{{ ((platform_optional_apps | default({})).espocrm | default({})).enabled | default(false) | bool }}"
+  when: item.enabled | bool
+  changed_when: >
+    optional_namespace_apply.stdout is defined and
+    ('created' in optional_namespace_apply.stdout or 'configured' in optional_namespace_apply.stdout)
+  register: optional_namespace_apply
+
 - name: Apply platform secrets
   ansible.builtin.command:
     argv:
@@ -336,6 +363,68 @@
       namespace: kube-system
       data:
         token: "{{ platform_secrets.cloudflare_tunnel_token }}"
+
+- name: Apply Twenty optional app secret
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - apply
+      - -f
+      - "-"
+  args:
+    stdin: >-
+      {{
+        {
+          'apiVersion': 'v1',
+          'kind': 'Secret',
+          'metadata': {
+            'name': 'twenty-secrets',
+            'namespace': 'twenty'
+          },
+          'type': 'Opaque',
+          'stringData': {
+            'PG_DATABASE_PASSWORD': platform_secrets.twenty_pg_database_password | default(''),
+            'ENCRYPTION_KEY': platform_secrets.twenty_encryption_key | default(''),
+            'APP_SECRET': platform_secrets.twenty_app_secret | default('')
+          }
+        } | to_nice_yaml
+      }}
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  no_log: true
+  when: ((platform_optional_apps | default({})).twenty | default({})).enabled | default(false) | bool
+
+- name: Apply EspoCRM optional app secret
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - apply
+      - -f
+      - "-"
+  args:
+    stdin: >-
+      {{
+        {
+          'apiVersion': 'v1',
+          'kind': 'Secret',
+          'metadata': {
+            'name': 'espocrm-secrets',
+            'namespace': 'espocrm'
+          },
+          'type': 'Opaque',
+          'stringData': {
+            'MARIADB_ROOT_PASSWORD': platform_secrets.espocrm_db_root_password | default(''),
+            'MARIADB_PASSWORD': platform_secrets.espocrm_db_password | default(''),
+            'ESPOCRM_ADMIN_PASSWORD': platform_secrets.espocrm_admin_password | default('')
+          }
+        } | to_nice_yaml
+      }}
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  no_log: true
+  when: ((platform_optional_apps | default({})).espocrm | default({})).enabled | default(false) | bool
 
 - name: Apply Grafana admin secret
   ansible.builtin.command:

--- a/ansible/roles/platform_validation/tasks/main.yml
+++ b/ansible/roles/platform_validation/tasks/main.yml
@@ -5,6 +5,8 @@
       KUBECONFIG: /home/k3s-admin/.kube/config
     platform_validation_default_argo_app_statuses:
       - Synced Healthy
+    platform_validation_twenty_enabled: "{{ ((platform_optional_apps | default({})).twenty | default({})).enabled | default(false) | bool }}"
+    platform_validation_espocrm_enabled: "{{ ((platform_optional_apps | default({})).espocrm | default({})).enabled | default(false) | bool }}"
 
 - name: Check Kubernetes API connectivity
   ansible.builtin.command:
@@ -72,6 +74,49 @@
       platform_validation_default_argo_app_statuses +
       (platform_validation_argo_app_allowed_statuses[item.item] | default([]))
     )
+
+- name: Check optional CRM Argo application status
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - application
+      - "{{ item.name }}"
+      - -n
+      - argocd
+      - -o
+      - "jsonpath={.status.sync.status} {.status.health.status}"
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  loop:
+    - name: platform-crm-twenty
+      enabled: "{{ platform_validation_twenty_enabled }}"
+    - name: platform-crm-espocrm
+      enabled: "{{ platform_validation_espocrm_enabled }}"
+  register: optional_crm_app_status
+  until: >
+    optional_crm_app_status.rc == 0 and
+    (optional_crm_app_status.stdout | default('') | trim) in platform_validation_default_argo_app_statuses
+  retries: "{{ platform_validation_argo_app_status_retries | default(60) }}"
+  delay: "{{ platform_validation_argo_app_status_delay | default(10) }}"
+  changed_when: false
+  failed_when: false
+  when: item.enabled | bool
+
+- name: Fail if optional CRM Argo application is missing or unhealthy
+  ansible.builtin.fail:
+    msg: >-
+      Argo application {{ item.item.name }} is not ready
+      (rc={{ item.rc }}, status={{ item.stdout | default('') | trim | default('missing', true) }},
+      expected={{ platform_validation_default_argo_app_statuses | join(' or ') }},
+      stderr={{ item.stderr | default('') | trim | default('none', true) }}).
+  loop: "{{ optional_crm_app_status.results | default([]) }}"
+  when:
+    - item.item.enabled | bool
+    - >
+      item.rc != 0 or
+      (item.stdout | default('') | trim) not in platform_validation_default_argo_app_statuses
 
 - name: Check Cloudflare tunnel deployment
   ansible.builtin.command:
@@ -338,6 +383,107 @@
   changed_when: false
   failed_when: baserow_web.rc != 0
 
+- name: Check Twenty backup CronJob
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - cronjob
+      - twenty-backup
+      - -n
+      - twenty
+      - -o
+      - name
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: twenty_backup_cron
+  changed_when: false
+  failed_when: twenty_backup_cron.rc != 0 or twenty_backup_cron.stdout | default('') | trim != 'cronjob.batch/twenty-backup'
+  when: platform_validation_twenty_enabled | bool
+
+- name: Check EspoCRM backup CronJob
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - cronjob
+      - espocrm-backup
+      - -n
+      - espocrm
+      - -o
+      - name
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: espocrm_backup_cron
+  changed_when: false
+  failed_when: espocrm_backup_cron.rc != 0 or espocrm_backup_cron.stdout | default('') | trim != 'cronjob.batch/espocrm-backup'
+  when: platform_validation_espocrm_enabled | bool
+
+- name: Verify Twenty optional CRM service is reachable
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - run
+      - "twenty-web-validation-{{ platform_probe_validation_timestamp.stdout }}"
+      - -n
+      - twenty
+      - --rm=true
+      - --attach=true
+      - -i
+      - --restart=Never
+      - --image=curlimages/curl:8.8.0
+      - --quiet=true
+      - --
+      - sh
+      - -ceu
+      - |
+        curl -fsS --max-time 20 http://twenty/healthz >/tmp/twenty-health.txt
+        curl -fsS --max-time 20 \
+          -H "Host: twenty.thekeepstudios.com" \
+          -H "X-Forwarded-Proto: https" \
+          http://twenty/ > /tmp/twenty.html
+        grep -Eiq "twenty|login|sign|workspace" /tmp/twenty.html
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: twenty_web
+  changed_when: false
+  failed_when: twenty_web.rc != 0
+  when: platform_validation_twenty_enabled | bool
+
+- name: Verify EspoCRM optional CRM service is reachable
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - run
+      - "espocrm-web-validation-{{ platform_probe_validation_timestamp.stdout }}"
+      - -n
+      - espocrm
+      - --rm=true
+      - --attach=true
+      - -i
+      - --restart=Never
+      - --image=curlimages/curl:8.8.0
+      - --quiet=true
+      - --
+      - sh
+      - -ceu
+      - |
+        curl -fsS --max-time 20 \
+          -H "Host: espocrm.thekeepstudios.com" \
+          -H "X-Forwarded-Proto: https" \
+          http://espocrm/ > /tmp/espocrm.html
+        grep -Eiq "espocrm|login|username|password" /tmp/espocrm.html
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: espocrm_web
+  changed_when: false
+  failed_when: espocrm_web.rc != 0
+  when: platform_validation_espocrm_enabled | bool
+
 - name: Read Leantime backup validation timestamp
   ansible.builtin.command:
     argv:
@@ -492,15 +638,7 @@
     url: "{{ item }}"
     status_code: [200, 401, 403]
     timeout: 15
-  loop:
-    - https://auth.thekeepstudios.com
-    - https://projects.thekeepstudios.com
-    - https://mindmaps.thekeepstudios.com
-    - https://relationships.thekeepstudios.com
-    - https://grafana.thekeepstudios.com
-    - https://prometheus.thekeepstudios.com
-    - https://alerts.thekeepstudios.com
-    - https://argocd.thekeepstudios.com
+  loop: "{{ ['https://auth.thekeepstudios.com', 'https://projects.thekeepstudios.com', 'https://mindmaps.thekeepstudios.com', 'https://relationships.thekeepstudios.com', 'https://grafana.thekeepstudios.com', 'https://prometheus.thekeepstudios.com', 'https://alerts.thekeepstudios.com', 'https://argocd.thekeepstudios.com'] + (['https://twenty.thekeepstudios.com'] if (platform_validation_twenty_enabled | bool) else []) + (['https://espocrm.thekeepstudios.com'] if (platform_validation_espocrm_enabled | bool) else []) }}"
   when: require_external_https | default(true) | bool
 
 - name: Verify protected endpoints require authentication

--- a/ansible/roles/platform_validation/tasks/main.yml
+++ b/ansible/roles/platform_validation/tasks/main.yml
@@ -41,6 +41,7 @@
     - platform-authentik
     - platform-leantime
     - platform-wisemapping
+    - platform-baserow
     - platform-monitoring-prometheus
     - platform-monitoring-loki
   register: app_status
@@ -108,6 +109,24 @@
   changed_when: false
   failed_when: backup_cron.rc != 0 or backup_cron.stdout | default('') | trim | length == 0
 
+- name: Check Baserow backup CronJob
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - cronjob
+      - baserow-backup
+      - -n
+      - baserow
+      - -o
+      - name
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: baserow_backup_cron
+  changed_when: false
+  failed_when: baserow_backup_cron.rc != 0 or baserow_backup_cron.stdout | default('') | trim != 'cronjob.batch/baserow-backup'
+
 - name: Verify platform alert rules are reconciled
   ansible.builtin.command:
     argv:
@@ -126,7 +145,9 @@
   failed_when: >
     prometheus_rules.rc != 0 or
     not (prometheus_rules.stdout is search('LeantimeBackupFailed')) or
+    not (prometheus_rules.stdout is search('BaserowBackupFailed')) or
     not (prometheus_rules.stdout is search('WiseMappingBackendUnavailable')) or
+    not (prometheus_rules.stdout is search('BaserowUnavailable')) or
     not (prometheus_rules.stdout is search('GrafanaUnavailable')) or
     not (prometheus_rules.stdout is search('LokiUnavailable')) or
     not (prometheus_rules.stdout is search('PromtailUnavailable'))
@@ -193,6 +214,25 @@
   failed_when: leantime_logs_dashboard.rc != 0 or leantime_logs_dashboard.stdout | default('') | trim != '1'
   when: monitoring_enabled | default(true) | bool
 
+- name: Verify Baserow logs dashboard is reconciled
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - configmap
+      - baserow-logs-dashboard
+      - -n
+      - monitoring
+      - -o
+      - "jsonpath={.metadata.labels.grafana_dashboard}"
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: baserow_logs_dashboard
+  changed_when: false
+  failed_when: baserow_logs_dashboard.rc != 0 or baserow_logs_dashboard.stdout | default('') | trim != '1'
+  when: monitoring_enabled | default(true) | bool
+
 - name: Read platform probe validation timestamp
   ansible.builtin.command:
     argv:
@@ -205,6 +245,7 @@
   ansible.builtin.set_fact:
     loki_volume_validation_pod_name: "loki-volume-validation-{{ platform_probe_validation_timestamp.stdout }}"
     wisemapping_api_validation_pod_name: "wisemapping-api-validation-{{ platform_probe_validation_timestamp.stdout }}"
+    baserow_web_validation_pod_name: "baserow-web-validation-{{ platform_probe_validation_timestamp.stdout }}"
     loki_volume_validation_start_ns: "{{ ((platform_probe_validation_timestamp.stdout | int) - 900) ~ '000000000' }}"
     loki_volume_validation_end_ns: "{{ (platform_probe_validation_timestamp.stdout | int) ~ '000000000' }}"
 
@@ -266,6 +307,36 @@
   register: wisemapping_backend_api
   changed_when: false
   failed_when: wisemapping_backend_api.rc != 0
+
+- name: Verify Baserow web service is reachable
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - run
+      - "{{ baserow_web_validation_pod_name }}"
+      - -n
+      - baserow
+      - --rm=true
+      - --attach=true
+      - -i
+      - --restart=Never
+      - --image=curlimages/curl:8.8.0
+      - --quiet=true
+      - --
+      - sh
+      - -ceu
+      - |
+        curl -fsS --max-time 20 \
+          -H "Host: relationships.thekeepstudios.com" \
+          -H "X-Forwarded-Proto: https" \
+          http://baserow/ > /tmp/baserow.html
+        grep -Eiq "baserow|login|sign" /tmp/baserow.html
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: baserow_web
+  changed_when: false
+  failed_when: baserow_web.rc != 0
 
 - name: Read Leantime backup validation timestamp
   ansible.builtin.command:
@@ -425,6 +496,7 @@
     - https://auth.thekeepstudios.com
     - https://projects.thekeepstudios.com
     - https://mindmaps.thekeepstudios.com
+    - https://relationships.thekeepstudios.com
     - https://grafana.thekeepstudios.com
     - https://prometheus.thekeepstudios.com
     - https://alerts.thekeepstudios.com

--- a/ansible/setup_k3s_production.yml
+++ b/ansible/setup_k3s_production.yml
@@ -90,6 +90,51 @@
       become: false
       tags: [always]
 
+    - name: Normalize optional CRM app flags
+      ansible.builtin.set_fact:
+        platform_optional_twenty_enabled: "{{ ((platform_optional_apps | default({})).twenty | default({})).enabled | default(false) | bool }}"
+        platform_optional_espocrm_enabled: "{{ ((platform_optional_apps | default({})).espocrm | default({})).enabled | default(false) | bool }}"
+      tags: [always]
+
+    - name: Define required optional CRM secret keys
+      ansible.builtin.set_fact:
+        required_optional_crm_secret_keys: >-
+          {{
+            (['twenty_pg_database_password', 'twenty_encryption_key', 'twenty_app_secret'] if (platform_optional_twenty_enabled | bool) else []) +
+            (['espocrm_db_root_password', 'espocrm_db_password', 'espocrm_admin_password'] if (platform_optional_espocrm_enabled | bool) else [])
+          }}
+      tags: [always]
+
+    - name: Detect missing optional CRM secrets
+      ansible.builtin.set_fact:
+        missing_optional_crm_secret_keys: "{{ required_optional_crm_secret_keys | difference(platform_secrets.keys() | list) }}"
+      when: required_optional_crm_secret_keys | length > 0
+      tags: [always]
+
+    - name: Fail if optional CRM secrets are missing
+      ansible.builtin.fail:
+        msg: "production_vars.yml is missing optional CRM platform_secrets keys: {{ missing_optional_crm_secret_keys | join(', ') }}"
+      when:
+        - required_optional_crm_secret_keys | length > 0
+        - missing_optional_crm_secret_keys | default([]) | length > 0
+      tags: [always]
+
+    - name: Fail if optional CRM secrets are empty or placeholders
+      ansible.builtin.fail:
+        msg: "The optional CRM production secret {{ item }} is empty or still set to a placeholder value."
+      vars:
+        secret_value: "{{ platform_secrets[item] | default('') | string }}"
+        normalized_secret_value: "{{ secret_value | trim | lower }}"
+      loop: "{{ required_optional_crm_secret_keys | default([]) }}"
+      when: >
+        (required_optional_crm_secret_keys | length > 0) and
+        (
+          (secret_value | trim | length == 0) or
+          (normalized_secret_value in production_placeholder_values) or
+          (normalized_secret_value is match('^(change[_-]?me|replace[_-]?me|todo|example|your[_ -]?value|your[_ -]?secret)'))
+        )
+      tags: [always]
+
     - name: Fail if WiseMapping OIDC is enabled without provider settings
       ansible.builtin.fail:
         msg: >-

--- a/docs/local-iac-testing.md
+++ b/docs/local-iac-testing.md
@@ -79,6 +79,7 @@ Supported profiles:
 static       Static IaC checks only.
 wisemapping  Static checks, k3d cluster, WiseMapping smoke test.
 leantime     Static checks, k3d cluster, Leantime smoke test.
+baserow      Static checks, k3d cluster, Baserow smoke test.
 platform     Static checks, k3d cluster, all local app smoke tests.
 ```
 
@@ -139,6 +140,7 @@ Use the generic target-based smoke entrypoint:
 ```bash
 scripts/dev-smoke.sh wisemapping
 scripts/dev-smoke.sh leantime
+scripts/dev-smoke.sh baserow
 scripts/dev-smoke.sh platform
 ```
 
@@ -147,6 +149,7 @@ Compatibility wrappers are also available:
 ```bash
 scripts/dev-wisemapping-smoke.sh
 scripts/dev-leantime-smoke.sh
+scripts/dev-baserow-smoke.sh
 scripts/dev-platform-smoke.sh
 ```
 
@@ -178,6 +181,16 @@ In a fresh local database, Leantime may redirect the login path to `/install`.
 That is accepted by the smoke and observation probes because it still proves the
 local app is serving a real first-run page.
 
+Baserow probes `http://baserow/` with:
+
+```text
+Host: relationships.thekeepstudios.com
+X-Forwarded-Proto: https
+```
+
+Baserow can take longer than the lighter apps on first pull/start because the
+all-in-one image includes the application, database, worker, and proxy pieces.
+
 The dev secrets are intentionally deterministic so repeated runs do not desync apps from existing local database PVCs. Override them only when you are also deleting the dev cluster or PVC:
 
 ```bash
@@ -192,6 +205,7 @@ After smoke tests pass, open the actual running app:
 ```bash
 scripts/dev-observe.sh wisemapping
 scripts/dev-observe.sh leantime
+scripts/dev-observe.sh baserow
 scripts/dev-observe.sh platform
 ```
 
@@ -200,6 +214,7 @@ Compatibility wrappers are also available:
 ```bash
 scripts/dev-wisemapping-observe.sh
 scripts/dev-leantime-observe.sh
+scripts/dev-baserow-observe.sh
 scripts/dev-platform-observe.sh
 ```
 
@@ -216,6 +231,7 @@ Default local URLs:
 ```text
 WiseMapping: http://localhost:18081
 Leantime:    http://localhost:18080
+Baserow:     http://localhost:18082
 ```
 
 The artifacts include:
@@ -258,6 +274,7 @@ Useful overrides:
 ```bash
 WISEMAPPING_OBSERVE_PORT=18082 scripts/dev-observe.sh wisemapping
 LEANTIME_OBSERVE_PORT=18083 scripts/dev-observe.sh leantime
+BASEROW_OBSERVE_PORT=18084 scripts/dev-observe.sh baserow
 DEV_OBSERVE_ARTIFACT_ROOT=/tmp/platform-observe scripts/dev-observe.sh platform
 DEV_OBSERVE_PATCH_CONFIG=false scripts/dev-observe.sh wisemapping
 ```

--- a/docs/local-iac-testing.md
+++ b/docs/local-iac-testing.md
@@ -80,6 +80,10 @@ static       Static IaC checks only.
 wisemapping  Static checks, k3d cluster, WiseMapping smoke test.
 leantime     Static checks, k3d cluster, Leantime smoke test.
 baserow      Static checks, k3d cluster, Baserow smoke test.
+twenty       Static checks, k3d cluster, Twenty smoke test.
+espocrm      Static checks, k3d cluster, EspoCRM smoke test.
+optional-crm Static checks, k3d cluster, both optional CRM smoke tests.
+crm-bakeoff  Compatibility alias for optional-crm.
 platform     Static checks, k3d cluster, all local app smoke tests.
 ```
 
@@ -141,6 +145,9 @@ Use the generic target-based smoke entrypoint:
 scripts/dev-smoke.sh wisemapping
 scripts/dev-smoke.sh leantime
 scripts/dev-smoke.sh baserow
+scripts/dev-smoke.sh twenty
+scripts/dev-smoke.sh espocrm
+scripts/dev-smoke.sh optional-crm
 scripts/dev-smoke.sh platform
 ```
 
@@ -150,6 +157,10 @@ Compatibility wrappers are also available:
 scripts/dev-wisemapping-smoke.sh
 scripts/dev-leantime-smoke.sh
 scripts/dev-baserow-smoke.sh
+scripts/dev-twenty-smoke.sh
+scripts/dev-espocrm-smoke.sh
+scripts/dev-optional-crm-smoke.sh
+scripts/dev-crm-bakeoff-smoke.sh
 scripts/dev-platform-smoke.sh
 ```
 
@@ -191,6 +202,24 @@ X-Forwarded-Proto: https
 Baserow can take longer than the lighter apps on first pull/start because the
 all-in-one image includes the application, database, worker, and proxy pieces.
 
+The optional CRM targets are intentionally not part of the default `platform`
+target because they are heavier candidates. Use `twenty`, `espocrm`, or
+`optional-crm` explicitly. `crm-bakeoff` is kept as a compatibility alias.
+
+Twenty probes `http://twenty/healthz` and then `http://twenty/` with:
+
+```text
+Host: twenty.thekeepstudios.com
+X-Forwarded-Proto: https
+```
+
+EspoCRM probes `http://espocrm/` with:
+
+```text
+Host: espocrm.thekeepstudios.com
+X-Forwarded-Proto: https
+```
+
 The dev secrets are intentionally deterministic so repeated runs do not desync apps from existing local database PVCs. Override them only when you are also deleting the dev cluster or PVC:
 
 ```bash
@@ -206,6 +235,9 @@ After smoke tests pass, open the actual running app:
 scripts/dev-observe.sh wisemapping
 scripts/dev-observe.sh leantime
 scripts/dev-observe.sh baserow
+scripts/dev-observe.sh twenty
+scripts/dev-observe.sh espocrm
+scripts/dev-observe.sh optional-crm
 scripts/dev-observe.sh platform
 ```
 
@@ -215,6 +247,10 @@ Compatibility wrappers are also available:
 scripts/dev-wisemapping-observe.sh
 scripts/dev-leantime-observe.sh
 scripts/dev-baserow-observe.sh
+scripts/dev-twenty-observe.sh
+scripts/dev-espocrm-observe.sh
+scripts/dev-optional-crm-observe.sh
+scripts/dev-crm-bakeoff-observe.sh
 scripts/dev-platform-observe.sh
 ```
 
@@ -232,6 +268,8 @@ Default local URLs:
 WiseMapping: http://localhost:18081
 Leantime:    http://localhost:18080
 Baserow:     http://localhost:18082
+Twenty:      http://localhost:18083
+EspoCRM:     http://localhost:18084
 ```
 
 The artifacts include:

--- a/docs/newapps-leantime-csv-import-plan.md
+++ b/docs/newapps-leantime-csv-import-plan.md
@@ -1,0 +1,214 @@
+# New Apps Leantime PM Import Plan
+
+This document plans how to turn `docs/newappsplan.md` into Leantime project-management records without losing sight of the actual goal: start capturing and organizing strategic relationship work from conventions, events, and partner conversations.
+
+The source strategy lives in `docs/newappsplan.md`. This document is only an optional project-management import helper.
+
+## Source Plan
+
+Input document:
+
+- `docs/newappsplan.md`
+
+The plan is about selecting and sequencing new application work around:
+
+- Relationship OS MVP, likely starting with Baserow.
+- Manual data boundaries between GetBuddy rescue operations and the Relationship OS.
+- Governance fields for future portability and permissions.
+- GetBuddy evaluation before committing sensitive rescue data.
+- Corteza re-evaluation after real usage proves whether Baserow is too limited.
+- CiviCRM as a later nonprofit CRM option, not the immediate MVP.
+
+## Leantime Import Path
+
+Use a manual or CSV-backed import path first.
+
+Do not block the Relationship OS planning work on Leantime MCP automation.
+
+Reasoning:
+
+- The strategic app plan is the important artifact.
+- The immediate business need is to record useful relationship context from real events and conversations.
+- Leantime import automation is helpful only if it saves time without creating a separate integration project.
+- The MCP setup/debugging path has already exceeded the value of automating this one planning import.
+
+Leantime's CSV importer supports common objects including To-Dos, Milestones, Users, Projects, Ideas, and Goals. The official support article points to import templates for each supported object type:
+
+- <https://support.leantime.io/en/article/importing-data-via-csv-1v941gy/>
+
+Generated CSV or JSON staging artifacts should live outside normal Git history:
+
+```text
+.artifacts/leantime-import/newapps/
+```
+
+That keeps the repository focused on durable infrastructure and planning while still giving PMs reviewable import files.
+
+## MCP Decision
+
+MCP is deferred for this workflow.
+
+Decision recorded on 2026-05-31:
+
+- Leantime MCP server-side discovery worked and reported tools.
+- Local MCP bridge/client behavior was not reliable enough to justify continued setup during this planning task.
+- The effort was becoming a project-management automation rabbit hole instead of helping capture the actual relationship strategy.
+- The MCP plugin can be revisited later as a separate infrastructure/PM operations task.
+
+Do not remove the strategic plan because MCP was not ready. The failed automation attempt does not invalidate the Baserow/GetBuddy/Corteza planning work.
+
+## Proposed Leantime Shape
+
+Create one Leantime project:
+
+```text
+Project: New Apps Evaluation and Relationship OS MVP
+```
+
+Purpose:
+
+```text
+Evaluate and sequence the next application layer for TKS and Full Hearts, starting with a Relationship OS MVP while preserving data boundaries, exportability, and future migration paths.
+```
+
+## Record Creation Order
+
+Create records in this order:
+
+1. Project
+2. Goals
+3. Milestones
+4. Ideas
+5. To-dos
+
+Users are omitted for now unless the importing PM wants assignees created or updated in the same pass.
+
+Before creating final CSVs, confirm the exact fields Leantime expects from the current import templates.
+
+## CSV Files To Prepare
+
+1. `01-projects.csv`
+2. `02-goals.csv`
+3. `03-milestones.csv`
+4. `04-ideas.csv`
+5. `05-todos.csv`
+
+Before generating final CSVs, download the current Leantime templates from the import UI or the official linked template sheet, then map these planned fields to the exact headers Leantime expects.
+
+## Project CSV
+
+Target record:
+
+```text
+Name: New Apps Evaluation and Relationship OS MVP
+Client / Organization: The Keep Studios
+Status: Active
+Description: Evaluate Baserow, GetBuddy, Corteza, and related governance decisions for the next app layer.
+```
+
+If Leantime requires a client/company field and no matching client exists, create or select:
+
+```text
+The Keep Studios
+```
+
+## Goals CSV
+
+Proposed goals:
+
+| Goal | Outcome |
+| --- | --- |
+| Launch Relationship OS MVP | Baserow is either accepted as MVP or rejected with clear reasons. |
+| Preserve Data Boundaries | Rescue operations data is not silently copied into business relationship tooling. |
+| Validate GetBuddy Exit Safety | Full Hearts understands export, deletion, attachment, notes, and privacy constraints before relying on GetBuddy. |
+| Define Graduation Criteria | The team knows when to stay on Baserow, migrate to Corteza, or defer both. |
+| Keep Future Handoff Easy | Schema, governance fields, and decisions are documented enough for another operator or consultant to understand. |
+
+## Milestones CSV
+
+Proposed milestones:
+
+| Milestone | Purpose | Suggested Status |
+| --- | --- | --- |
+| Import Setup and Template Validation | Confirm Leantime CSV headers, import order, and project shell. | Ready |
+| Relationship OS MVP Design | Define Baserow tables, governance fields, and manual promotion workflow. | Ready |
+| Baserow MVP Implementation | Stand up and validate the first usable Relationship OS prototype. | Planned |
+| GetBuddy Evaluation | Answer export, deletion, privacy, and rescue-data questions before operational reliance. | Planned |
+| Corteza Re-Evaluation | Decide whether actual usage justifies graduating beyond Baserow. | Planned |
+| Decision and Next Build Plan | Convert evaluation results into a concrete implementation path. | Planned |
+
+## Ideas CSV
+
+Import as Ideas if Leantime is being used to preserve strategic alternatives separately from actionable work.
+
+| Idea | Notes |
+| --- | --- |
+| Start with Baserow, design for possible Corteza migration | Fast MVP without throwing away future data-shape thinking. |
+| Keep humans as the API between GetBuddy and Relationship OS | Prevent silent copying of sensitive rescue data. |
+| Preserve governance fields without complex RBAC | Keep future permissions possible without building a permissions system now. |
+| Require written GetBuddy export answers | Do not put sensitive rescue data into a tool without exit clarity. |
+| Revisit Corteza after 30 to 60 days | Let real usage decide whether Baserow limits matter. |
+| Defer CiviCRM | Useful later for donor/event/fundraising gravity, not for this MVP. |
+
+## To-Dos CSV
+
+Proposed import rows. Exact status, priority, estimate, and milestone fields should be mapped to the current Leantime template.
+
+| Milestone | To-Do | Description | Priority |
+| --- | --- | --- | --- |
+| Import Setup and Template Validation | Download current Leantime CSV templates | Get official templates for Projects, Goals, Milestones, Ideas, and To-Dos before generating final CSVs. | High |
+| Import Setup and Template Validation | Confirm import order in a small test | Import one project, one milestone, and one to-do before bulk import. | High |
+| Import Setup and Template Validation | Decide whether assignees are needed | If yes, prepare Users CSV or map tasks to existing Leantime users. | Medium |
+| Relationship OS MVP Design | Define People table | Include identity, organization links, purpose, consent notes, sensitive flag, and do-not-use-for fields. | High |
+| Relationship OS MVP Design | Define Organizations table | Include org type, owning entity, relationship status, strategic relevance, and notes. | High |
+| Relationship OS MVP Design | Define Roles and Affiliations table | Model many-to-many people-to-organization roles without flattening important context. | High |
+| Relationship OS MVP Design | Define Touchpoints table | Capture intentional interactions, dates, owners, outcomes, and next actions. | Medium |
+| Relationship OS MVP Design | Define Opportunities and Strategic Moves table | Track introductions, partnerships, donor moves, contractor opportunities, and follow-up state. | Medium |
+| Relationship OS MVP Design | Define Contractors and Creatives table | Separate vendor/creative pipeline data from general contacts where useful. | Medium |
+| Relationship OS MVP Design | Define Entity Boundary and Consent Notes fields | Preserve TKS / Full Hearts / Shared ownership, consent notes, sensitive flag, and do-not-use-for context. | High |
+| Relationship OS MVP Design | Define manual promotion rule from GetBuddy | Document that GetBuddy data enters Relationship OS only by intentional human promotion. | High |
+| Baserow MVP Implementation | Stand up Baserow workspace | Create the Relationship OS prototype workspace and initial tables. | High |
+| Baserow MVP Implementation | Configure forms and views | Create useful entry forms, Kanban/calendar-style views if available, and simple operator views. | Medium |
+| Baserow MVP Implementation | Add sample records | Use non-sensitive sample data to validate the schema and workflows. | High |
+| Baserow MVP Implementation | Validate export path | Confirm CSV/API export is usable for the MVP data shape. | High |
+| Baserow MVP Implementation | Write MVP operating notes | Document how contacts are added, promoted, reviewed, and cleaned up. | Medium |
+| GetBuddy Evaluation | Ask GetBuddy export questions | Confirm full export, attachments, notes, application history, deletion on exit, and privacy/targeting constraints. | High |
+| GetBuddy Evaluation | Record GetBuddy answers in Leantime | Attach or summarize written answers in the project. | High |
+| GetBuddy Evaluation | Decide acceptable rescue-data usage | Decide what data may live in GetBuddy and what must stay out. | High |
+| Corteza Re-Evaluation | Define 30 to 60 day review criteria | List Baserow pain signals: workflows, permissions, reporting, API limits, and consulting/case-study value. | Medium |
+| Corteza Re-Evaluation | Re-check Corteza implementation cost | Estimate configuration labor, hosting, security, and handoff complexity after MVP usage. | Medium |
+| Corteza Re-Evaluation | Make stay/migrate/defer decision | Decide whether to stay on Baserow, migrate to Corteza, or defer the decision. | High |
+| Decision and Next Build Plan | Write final recommendation | Summarize chosen app path, rationale, risks, and next build steps. | High |
+| Decision and Next Build Plan | Convert accepted path into implementation backlog | Create follow-up Leantime tasks or a new project for the chosen app. | High |
+
+## Import Procedure
+
+1. Download fresh Leantime CSV templates.
+2. Generate draft CSVs under `.artifacts/leantime-import/newapps/`.
+3. Open the CSVs in a spreadsheet editor and review names, descriptions, statuses, priorities, and milestone mappings.
+4. Import `01-projects.csv`.
+5. Import `02-goals.csv`.
+6. Import `03-milestones.csv`.
+7. Import `04-ideas.csv`.
+8. Import `05-todos.csv`.
+9. Spot-check in Leantime:
+   - Project exists.
+   - Milestones are attached to the right project.
+   - To-dos are attached to the right milestone.
+   - Ideas and goals are readable and not duplicative.
+10. Export or screenshot the resulting project as evidence.
+
+## MCP Follow-Up Criteria
+
+Revisit MCP only as a separate task, not as a blocker for relationship planning.
+
+Pick MCP back up only if:
+
+- Token creation, rotation, and revocation are documented.
+- The MCP client configuration is documented without committing secrets.
+- Read/write scopes are understood.
+- We have a repeatable dry-run or staging-review workflow before writes.
+- We know how to audit what the agent changed in Leantime.
+- The expected time savings are larger than the setup and maintenance burden.
+
+If MCP becomes a normal workflow, document it as infrastructure and PM operations work, not as an ad-hoc shortcut.

--- a/docs/newappsplan.md
+++ b/docs/newappsplan.md
@@ -1,0 +1,129 @@
+Your instinct is mostly right.
+
+Your colleague is **correct on MVP discipline**, but I think they’re slightly overcorrecting toward “simplest tool now” and underweighting “will this still be the right data shape in six months?”
+
+## My read
+
+### 1. “Baserow over Corteza” is reasonable, not obviously correct
+
+Baserow is attractive because it’s fast to stand up, table-shaped, form-friendly, API-first, and easy for humans to understand. Its docs show forms, Kanban/calendar-style views, API docs, table-level tokens, webhooks, permissions, snapshots, and audit-log concepts. That’s plenty for an MVP relationship board. ([Baserow][1])
+
+But Corteza is not being disqualified by hardware. Corteza’s own requirement table says 1–500 users is **1 vCPU / 2 GB RAM**, with PostgreSQL recommended. That is trivial on a maxed Framework Desktop. ([docs.cortezaproject.org][2])
+
+The real question is **configuration labor**, not resource footprint.
+
+So I’d reframe it:
+
+> Baserow is better for “start using this tomorrow.”
+> Corteza is better for “build a governed relationship application.”
+
+Given your actual need is “executive who’s-who system,” Baserow might be enough. Given your TKS consulting/portfolio goal, Corteza is still strategically interesting.
+
+### 2. They are dead right on “humans as the API”
+
+Strong agree. No sync workers yet.
+
+Manual elevation is the right MVP rule:
+
+> GetBuddy contains rescue ops.
+> Relationship OS contains only strategic contacts someone intentionally promotes.
+
+No ETL. No silent sync. No background job that quietly copies sensitive rescue data into a quasi-business system.
+
+### 3. Flat permissions are fine, but only if the data is intentionally boring
+
+I agree with flattening permissions **for the first version**, but I would not remove the governance fields.
+
+Do not build complex RBAC yet. But keep fields like:
+
+```text
+Owning Entity: TKS / Full Hearts / Shared
+Contact Purpose: Business / Rescue / Donor / Creative / Vendor / Personal
+Consent Notes:
+Sensitive? Yes/No
+Do Not Use For:
+```
+
+That gives you future-proofing without building a permissions cathedral.
+
+### 4. Their GetBuddy advice is a little too trusting
+
+GetBuddy’s pitch is genuinely compelling: free, role-based access, application routing, white-glove migration, and “no hidden fees.” ([GetBuddy][3])
+
+But I would **not** “accept the privacy trade-offs for now” without one written answer: can Full Hearts export all records, notes, attachments, and application history if leaving?
+
+Also, GetBuddy’s privacy policy has language around targeted advertising and sharing practices that may qualify as a “sale” under some state privacy laws. That doesn’t prove misuse, but it means “free forever” needs written clarification before you hand them sensitive adopter/foster/volunteer data. ([GetBuddy][4])
+
+### 5. CiviCRM still probably isn’t the MVP answer
+
+CiviCRM is absolutely worth respecting. It owns nonprofit CRM territory: contributions, memberships, accounting export, case management, events, email marketing, peer-to-peer fundraising, reports, and CMS integration. ([civicrm.org][5])
+
+But its own docs call it “a demanding web application,” with PHP/MySQL/MariaDB requirements, and PostgreSQL is not compatible. ([docs.civicrm.org][6])
+
+On your hardware, it would run. The issue is **wrong shape and maintenance gravity**. It’s more useful if Full Hearts becomes donor/event/fundraising heavy. It is not the best tool for a cross-org executive relationship map.
+
+## My recommendation
+
+Do this:
+
+### Phase 1: Baserow MVP
+
+Use Baserow for the **Relationship OS prototype** because your colleague is right about speed-to-value.
+
+Tables:
+
+```text
+People
+Organizations
+Roles / Affiliations
+Touchpoints
+Opportunities / Strategic Moves
+Contractors & Creatives
+Entity Boundary / Consent Notes
+```
+
+Keep it manual. No sync.
+
+### Phase 2: GetBuddy evaluation
+
+Use GetBuddy only if they pass:
+
+```text
+Full export?
+Attachments included?
+Notes included?
+Application history included?
+Data deletion on exit?
+No rescue-submitted contact data used for sponsored targeting?
+```
+
+### Phase 3: Re-evaluate Corteza after actual use
+
+After 30–60 days, ask:
+
+* Are we fighting Baserow’s limits?
+* Do we need real workflows?
+* Do we need stronger permissions?
+* Do we want this as a public TKS case study?
+* Do we want reusable “Relationship OS for small mission orgs” consulting collateral?
+
+If yes, migrate the proven schema to Corteza.
+
+## Blunt call
+
+Your colleague is right that the **first implementation should be simpler**.
+
+You are right that **hardware is not the constraint**.
+
+The compromise is:
+
+> **Start with Baserow, but design the schema like it may graduate to Corteza.**
+
+That avoids yak-shaving while preserving the bigger TKS software/consulting story.
+
+[1]: https://baserow.io/user-docs/database-api "Baserow Database API documentation"
+[2]: https://docs.cortezaproject.org/corteza-docs/2024.9/devops-guide/system-requirements.html "System Requirements :: Corteza Docs"
+[3]: https://www.getbuddy.com/animal-shelter-rescue-software "Buddy Pro - Free Shelter Management Software for Rescues and Shelters"
+[4]: https://www.getbuddy.com/privacy-policy "Privacy Policy | GetBuddy"
+[5]: https://civicrm.org/explore-civicrm "What is CiviCRM | CiviCRM"
+[6]: https://docs.civicrm.org/installation/en/latest/requirements/ "Requirements - CiviCRM Installation Guide - CiviCRM Documentation"

--- a/docs/optional-crm-apps.md
+++ b/docs/optional-crm-apps.md
@@ -1,0 +1,163 @@
+# Optional CRM Apps
+
+Baserow remains the core relationship-management app for now. Twenty and
+EspoCRM stay in the repo as optional apps that can be tested locally or enabled
+explicitly through GitOps.
+
+Use fake or low-risk sample data while comparing the CRMs. Do not import rescue,
+medical, adoption, private convention, or client data until an app has been
+deliberately chosen for that data class.
+
+## Local Test
+
+Run one candidate at a time:
+
+```bash
+scripts/dev-smoke.sh twenty
+scripts/dev-observe.sh twenty
+```
+
+```bash
+scripts/dev-smoke.sh espocrm
+scripts/dev-observe.sh espocrm
+```
+
+Run both candidates when the workstation has enough disk and memory:
+
+```bash
+scripts/dev-smoke.sh optional-crm
+scripts/dev-observe.sh optional-crm
+```
+
+The old `crm-bakeoff` target remains as a compatibility alias for local
+comparison:
+
+```bash
+scripts/dev-smoke.sh crm-bakeoff
+scripts/dev-observe.sh crm-bakeoff
+```
+
+Default local URLs:
+
+```text
+Twenty:  http://localhost:18083
+EspoCRM: http://localhost:18084
+```
+
+The smoke scripts create deterministic dev-only Kubernetes secrets in each app
+namespace. Override them only when also deleting the disposable cluster or PVCs.
+
+## GitOps Enablement
+
+Both apps are disabled by default:
+
+```yaml
+platform_optional_apps:
+  twenty:
+    enabled: false
+  espocrm:
+    enabled: false
+```
+
+Enable either app, or both, in `ansible/production_vars.yml`:
+
+```yaml
+platform_optional_apps:
+  twenty:
+    enabled: true
+  espocrm:
+    enabled: false
+```
+
+Add only the secrets required by the enabled app.
+
+Twenty:
+
+```yaml
+platform_secrets:
+  twenty_pg_database_password: "CHANGE_ME"
+  twenty_encryption_key: "CHANGE_ME"
+  twenty_app_secret: "CHANGE_ME"
+```
+
+EspoCRM:
+
+```yaml
+platform_secrets:
+  espocrm_db_root_password: "CHANGE_ME"
+  espocrm_db_password: "CHANGE_ME"
+  espocrm_admin_password: "CHANGE_ME"
+```
+
+If external HTTPS validation is enabled, include the enabled host in
+`direct_http_urls` so the direct-origin exposure check covers it too.
+
+```yaml
+direct_http_urls:
+  - "http://twenty.thekeepstudios.com"
+```
+
+or:
+
+```yaml
+direct_http_urls:
+  - "http://espocrm.thekeepstudios.com"
+```
+
+## Hostnames
+
+The optional app manifests use these external hosts:
+
+```text
+Twenty:  https://twenty.thekeepstudios.com
+EspoCRM: https://espocrm.thekeepstudios.com
+```
+
+Wire only enabled hosts through Cloudflare Tunnel.
+
+## Backups
+
+Each optional app includes its own backup CronJob:
+
+```text
+Twenty:  twenty/twenty-backup
+EspoCRM: espocrm/espocrm-backup
+```
+
+The backup jobs write compressed database dumps and app-local data archives to
+app-specific backup PVCs. Validate backups manually before putting real business
+data into either CRM.
+
+Manual backup examples:
+
+```bash
+kubectl create job -n twenty twenty-backup-manual-$(date +%s) \
+  --from=cronjob/twenty-backup
+```
+
+```bash
+kubectl create job -n espocrm espocrm-backup-manual-$(date +%s) \
+  --from=cronjob/espocrm-backup
+```
+
+## Cleanup
+
+Local cleanup:
+
+```bash
+kubectl delete namespace twenty
+kubectl delete namespace espocrm
+```
+
+Disposable-cluster cleanup:
+
+```bash
+scripts/dev-cluster-down.sh
+```
+
+Trial cleanup:
+
+1. Set the app's `platform_optional_apps.<app>.enabled` value to `false`.
+2. Re-render/apply GitOps.
+3. Confirm the selected Argo CD app disappears or is pruned intentionally.
+4. Delete app PVCs only after deciding no trial data needs to be kept.

--- a/docs/relationship-os/baserow-schema.md
+++ b/docs/relationship-os/baserow-schema.md
@@ -1,0 +1,157 @@
+# Baserow Schema
+
+Create two Baserow workspaces with the same starter schema:
+
+- `TKS Relationship OS`
+- `Full Hearts Strategic Relationships`
+
+Keep the schemas similar at first so the operating rhythm is shared, but keep
+the workspaces separate so TKS and Full Hearts data do not blur by default.
+
+## Tables
+
+### People
+
+Purpose: individual humans worth remembering, following up with, influencing,
+helping, hiring, partnering with, or asking for support.
+
+Fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| Full Name | Single line text | Required |
+| Preferred Name | Single line text | Optional |
+| Primary Email | Email | Leave blank if not appropriate to store |
+| Primary Phone | Phone number | Leave blank if not appropriate to store |
+| Location | Single line text | City, region, or convention context |
+| Relationship Owner | Collaborator or single select | Who owns follow-up |
+| Warmth | Single select | Cold, New, Warm, Active, Dormant |
+| Contact Purpose | Single select | Business, Rescue, Donor, Creative, Vendor, Personal |
+| Owning Entity | Single select | TKS, Full Hearts, Shared |
+| Sensitive | Boolean | Use for extra caution, not for fine-grained RBAC |
+| Do Not Use For | Long text | Explicit restrictions |
+| Consent Notes | Long text | Where permission/context came from |
+| Last Touchpoint At | Date | Update from touchpoint log |
+| Next Follow-Up At | Date | Drives calendar view |
+| Tags | Multiple select | Keep short |
+| Notes | Long text | Relationship context |
+
+Recommended views:
+
+- `All People`
+- `Needs Follow-Up`
+- `Warm Relationships`
+- `New Leads`
+- `Sensitive Review`
+
+### Organizations
+
+Purpose: companies, rescues, funders, stores, vendors, studios, press outlets,
+clinics, agencies, and institutions.
+
+Fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| Organization Name | Single line text | Required |
+| Organization Type | Single select | Publisher, Studio, Rescue, Funder, Vendor, Venue, Press, Clinic, Government, Other |
+| Website | URL | Optional |
+| Location | Single line text | HQ or relevant local market |
+| Strategic Value | Single select | Low, Medium, High, Critical |
+| Status | Single select | New, Active, Watching, Dormant, Blocked |
+| Primary Contact | Link to People | Optional |
+| Owning Entity | Single select | TKS, Full Hearts, Shared |
+| Notes | Long text | Why this org matters |
+
+Recommended views:
+
+- `Priority Organizations`
+- `Publishing Ecosystem`
+- `Rescue Ecosystem`
+- `Local Rochester`
+- `Vendors`
+
+### Roles / Affiliations
+
+Purpose: join people to organizations over time. This should be a real table
+instead of a text note because people move roles and organizations.
+
+Fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| Person | Link to People | Required |
+| Organization | Link to Organizations | Required |
+| Title / Role | Single line text | Optional |
+| Department / Team | Single line text | Optional |
+| Current | Boolean | True for current affiliation |
+| Start Date | Date | Optional |
+| End Date | Date | Optional |
+| Influence Score | Number | 1 to 5, subjective |
+| Notes | Long text | Context and caveats |
+
+Recommended views:
+
+- `Current Roles`
+- `Former Roles`
+- `High Influence`
+
+### Touchpoints
+
+Purpose: narrative log of interactions. This is the memory layer.
+
+Fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| Touched At | Date and time | Required |
+| Touchpoint Type | Single select | Meeting, Email, Call, Convention, Social, Intro, Donation, Volunteer, Other |
+| People | Link to People | Optional but preferred |
+| Organizations | Link to Organizations | Optional |
+| Summary | Single line text | Short, scannable |
+| Detailed Notes | Long text | Actual context |
+| Follow-Up Required | Boolean | Drives follow-up view |
+| Follow-Up At | Date | Optional |
+| Owner | Collaborator or single select | Responsible person |
+| Confidentiality | Single select | Normal, Internal, Sensitive |
+| Related Opportunities | Link to Opportunities | Optional |
+
+Recommended views:
+
+- `Logbook`
+- `Follow-Up Due`
+- `This Month`
+- `By Owner`
+
+### Opportunities
+
+Purpose: a concrete strategic move or possible move. If it turns into delivery
+work, move execution into a real project-management tool.
+
+Fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| Title | Single line text | Required |
+| Opportunity Type | Single select | Publishing, Consulting, Fundraising, Partnership, Event, Vendor, Press, Rescue Alliance, Other |
+| People | Link to People | Optional |
+| Organizations | Link to Organizations | Optional |
+| Stage | Single select | Idea, Qualifying, Active, Waiting, Won, Lost, Parked |
+| Estimated Value | Number | Optional dollars |
+| Nonfinancial Value | Single select | Low, Medium, High, Critical |
+| Owner | Collaborator or single select | Responsible person |
+| Target Date | Date | Drives calendar view |
+| Next Step | Long text | One concrete action |
+| Risk Notes | Long text | Risks, conflicts, sensitivities |
+
+Recommended views:
+
+- `Kanban by Stage`
+- `Calendar by Target Date`
+- `High Value`
+- `Waiting on Others`
+
+## Launch Rule
+
+Start with these tables and views only. Do not add automation until there is at
+least one month of real use and a clear repeated pain point.

--- a/docs/relationship-os/data-boundary-policy.md
+++ b/docs/relationship-os/data-boundary-policy.md
@@ -1,0 +1,94 @@
+# Data Boundary Policy
+
+The Relationship OS exists to track strategic relationships. It is not a rescue
+operations system and it is not a data lake.
+
+## Core Rule
+
+Humans are the API.
+
+Records may be entered or promoted into the Relationship OS only when a person
+intentionally decides the contact belongs in the strategic relationship layer.
+There is no automatic sync from GetBuddy, email, forms, spreadsheets, or other
+systems.
+
+
+## Allowed Data
+
+Allowed:
+
+- strategic contact information
+- affiliation and role context
+- relationship notes
+- follow-up dates
+- opportunity context
+- consent and boundary notes
+- high-level donor, partner, vendor, creative, or rescue-alliance context
+
+## Disallowed Data
+
+Do not store routine rescue operations data here:
+
+- animal medical records
+- adoption applications
+- foster screening data
+- volunteer screening data
+- adopter household details
+- animal intake histories
+- sensitive medical or behavioral notes about animals
+- donor receipt or tax substantiation records
+- private legal, employment, or HR records
+
+If this data is needed, keep it in the proper operations system or legal/accounting
+system.
+
+## Entity Boundary
+
+TKS and Full Hearts are connected, but they are not the same legal entity.
+
+Every strategic record should answer:
+
+- Which entity owns this relationship?
+- Why is it appropriate to store this contact here?
+- What should this contact not be used for?
+- Is the record sensitive?
+
+Use these fields:
+
+- `Owning Entity`
+- `Contact Purpose`
+- `Sensitive`
+- `Consent Notes`
+- `Do Not Use For`
+
+## Workspace Boundary
+
+Use two workspaces:
+
+- `TKS Relationship OS`
+- `Full Hearts Strategic Relationships`
+
+Do not assume workspace separation is a legal or technical air gap. Baserow
+instance admins can still administer the whole installation. Workspace separation
+is a practical operating boundary for small-team use.
+
+## Promotion Rule
+
+A record may move from rescue operations into the strategic workspace only when:
+
+1. It has a clear strategic purpose.
+2. The relationship owner can explain why it belongs there.
+3. The record excludes operationally sensitive details.
+4. Any restrictions are captured in `Consent Notes` and `Do Not Use For`.
+
+## Future Automation Rule
+
+Before adding automation, write a short design note that answers:
+
+- What data moves?
+- Who approved the movement?
+- What is the rollback path?
+- What logs prove the movement happened?
+- What privacy boundary could the automation violate?
+
+Until that note exists, keep the system manual.

--- a/docs/relationship-os/getbuddy-diligence.md
+++ b/docs/relationship-os/getbuddy-diligence.md
@@ -1,0 +1,37 @@
+# GetBuddy Diligence Checklist
+
+GetBuddy is a candidate for Full Hearts rescue operations only. It should not be
+treated as the Relationship OS and it should not automatically sync into Baserow.
+
+Get written answers before putting sensitive rescue operations data in GetBuddy.
+
+## Required Written Answers
+
+| Topic | Required answer |
+|---|---|
+| Full export | Can Full Hearts export all records, notes, attachments, applications, application history, medical records, and user metadata on demand? |
+| Export format | Are exports machine-readable, such as CSV, JSON, ZIP, or SQL dump? |
+| Exit support | What is the process and timeline if Full Hearts leaves the service? |
+| Deletion | Can Full Hearts request deletion from production systems, backups, analytics systems, and subprocessors? What timeline applies? |
+| Data ownership | Does Full Hearts remain the controller or owner of organization-submitted data? |
+| Advertising | Will adopter, foster, volunteer, donor, medical, or rescue-submitted data be used for targeted advertising, profiling, resale, or sponsored targeting? |
+| AI/model training | Will rescue-submitted data or support conversations be used to train or improve AI systems? Is there an opt-out? |
+| Subprocessors | What vendors process the data and where are they located? |
+| Security | Is MFA available for admins? What roles exist? What audit logs are available? |
+| Incident response | What notification timeline applies after a breach or suspected breach? |
+| Attachments | Are uploaded files included in export and deletion workflows? |
+| API access | Is API access available for export or reporting? Is it rate-limited? |
+| Pricing | What parts are free, what may become paid, and what notice is given before pricing changes? |
+
+## Decision Gate
+
+Use GetBuddy for rescue operations only if the written answers are acceptable to
+Full Hearts leadership.
+
+If GetBuddy fails diligence, do not make Baserow a rescue-operations substitute.
+Choose or build a separate rescue-ops system instead.
+
+## Relationship OS Boundary
+
+Even if GetBuddy is approved, Baserow receives only manually promoted strategic
+records. No automatic sync, no ETL, no background copy job.

--- a/docs/relationship-os/implementation-plan.md
+++ b/docs/relationship-os/implementation-plan.md
@@ -1,0 +1,85 @@
+# Relationship OS Implementation Plan
+
+This plan implements the Relationship OS MVP from `docs/newappsplan.md` and the
+research export. The goal is a usable strategic relationship map, not a rescue
+operations database and not a cross-system automation project.
+
+## Decision
+
+Use one self-hosted Baserow instance on The Keep Platform.
+
+Initial operating model:
+
+- Workspace: `TKS Relationship OS`
+- Workspace: `Full Hearts Strategic Relationships`
+- Manual record entry and manual promotion only
+- No sync workers
+- No ETL
+- No webhooks
+- No rescue medical, adoption, foster, or volunteer operations schema
+
+GetBuddy remains a written-diligence candidate for rescue operations only.
+
+## MVP Scope
+
+Included:
+
+- Baserow all-in-one Kubernetes Deployment
+- PVC mounted at `/baserow/data`
+- Internal service and Traefik Ingress for `relationships.thekeepstudios.com`
+- Argo CD app registration as `platform-baserow`
+- Daily quiet-window backup CronJob
+- Restore runbook
+- Schema and data-boundary docs
+- GetBuddy diligence checklist
+
+Excluded:
+
+- External PostgreSQL
+- External Redis
+- S3/object storage
+- automated imports
+- API sync jobs
+- public intake apps
+- advanced RBAC design
+- rescue operations workflow
+- donor management workflows
+
+## Rollout Checklist
+
+1. Create the Cloudflare Tunnel public hostname:
+   - Hostname: `relationships.thekeepstudios.com`
+   - Service type: `HTTPS`
+   - Service URL: `traefik.kube-system.svc.cluster.local`
+   - Origin setting: `No TLS Verify`
+2. Add Cloudflare Access in front of `relationships.thekeepstudios.com`.
+3. Apply or sync the `platform-baserow` Argo CD application.
+4. Wait for:
+   - `application/platform-baserow` to become `Synced Healthy`
+   - `deployment/baserow` to become available in namespace `baserow`
+5. Open Baserow and create the first admin account.
+6. Create the two workspaces.
+7. Build the tables from `baserow-schema.md`.
+8. Enter 5 to 10 real convention or partner contacts manually.
+9. Review the data-boundary policy before adding Full Hearts records.
+10. Confirm the backup CronJob exists.
+
+## Day-One Success Criteria
+
+The MVP is usable when:
+
+- Baserow loads through Cloudflare Access.
+- The two workspaces exist.
+- Core tables exist in each workspace.
+- At least one strategic contact can be entered manually.
+- Follow-up dates and opportunity stages can be viewed without custom code.
+- Backup and restore instructions are documented.
+
+## Non-Goals
+
+The Relationship OS is not the system of record for animal care, adoption,
+foster screening, medical history, donor receipts, or legal compliance records.
+
+The first version is intentionally boring. If the team uses it consistently for
+30 to 60 days, then evaluate whether Baserow is still enough or whether the
+schema should graduate into a more governed platform.

--- a/docs/relationship-os/restore-runbook.md
+++ b/docs/relationship-os/restore-runbook.md
@@ -1,0 +1,136 @@
+# Baserow Restore Runbook
+
+This runbook covers the MVP Baserow all-in-one deployment in
+`kubernetes/apps/baserow`.
+
+The backup CronJob creates full `/baserow/data` archives on the
+`baserow-backup-pvc`. It scales the Baserow Deployment to zero first, waits for
+the pod to terminate, archives the data directory, then scales the Deployment
+back to one replica.
+
+## Backup Location
+
+Namespace: `baserow`
+
+PVCs:
+
+- `baserow-data`: live Baserow data mounted at `/baserow/data`
+- `baserow-backup-pvc`: backup archives mounted at `/backup`
+
+Backup file pattern:
+
+```text
+/backup/baserow_data_YYYYMMDDTHHMMSSZ.tar.gz
+```
+
+## Check Backup Job Status
+
+```bash
+kubectl get cronjob,job,pod,pvc -n baserow | grep -E 'baserow|NAME'
+```
+
+Check the latest backup pod logs:
+
+```bash
+kubectl logs -n baserow job/$(kubectl get jobs -n baserow \
+  --sort-by=.metadata.creationTimestamp \
+  -o jsonpath='{.items[-1:].metadata.name}')
+```
+
+## Trigger a Manual Backup
+
+This temporarily takes Baserow offline.
+
+```bash
+kubectl create job -n baserow baserow-backup-manual-$(date +%s) \
+  --from=cronjob/baserow-backup
+```
+
+Wait for completion:
+
+```bash
+kubectl wait -n baserow --for=condition=complete --timeout=900s \
+  job/$(kubectl get jobs -n baserow \
+    --sort-by=.metadata.creationTimestamp \
+    -o jsonpath='{.items[-1:].metadata.name}')
+```
+
+## Validate an Archive
+
+Create a temporary pod that mounts the backup PVC and lists the archive contents:
+
+```bash
+kubectl run -n baserow baserow-backup-validator --rm -i --restart=Never \
+  --image=alpine:3.22 \
+  --overrides='
+{
+  "spec": {
+    "containers": [{
+      "name": "validator",
+      "image": "alpine:3.22",
+      "command": ["sh", "-ceu", "latest=$(ls -t /backup/baserow_data_*.tar.gz | head -1); test -s \"$latest\"; tar -tzf \"$latest\" | head -40"],
+      "volumeMounts": [{"name": "backup-data", "mountPath": "/backup"}]
+    }],
+    "volumes": [{"name": "backup-data", "persistentVolumeClaim": {"claimName": "baserow-backup-pvc"}}]
+  }
+}'
+```
+
+## Restore
+
+Restoring replaces the current Baserow data directory. Take a fresh backup first
+unless the PVC is already unusable.
+
+1. Stop Baserow:
+
+```bash
+kubectl scale deployment/baserow -n baserow --replicas=0
+kubectl wait -n baserow --for=delete pod -l app=baserow --timeout=600s
+```
+
+2. Restore the selected archive into the live PVC:
+
+```bash
+kubectl run -n baserow baserow-restore --rm -i --restart=Never \
+  --image=alpine:3.22 \
+  --overrides='
+{
+  "spec": {
+    "containers": [{
+      "name": "restore",
+      "image": "alpine:3.22",
+      "command": ["sh", "-ceu", "archive=/backup/REPLACE_WITH_ARCHIVE.tar.gz; rm -rf /baserow/data/*; tar -xzf \"$archive\" -C /baserow"],
+      "volumeMounts": [
+        {"name": "baserow-data", "mountPath": "/baserow/data"},
+        {"name": "backup-data", "mountPath": "/backup"}
+      ]
+    }],
+    "volumes": [
+      {"name": "baserow-data", "persistentVolumeClaim": {"claimName": "baserow-data"}},
+      {"name": "backup-data", "persistentVolumeClaim": {"claimName": "baserow-backup-pvc"}}
+    ]
+  }
+}'
+```
+
+Replace `REPLACE_WITH_ARCHIVE.tar.gz` with the actual filename before running.
+
+3. Start Baserow:
+
+```bash
+kubectl scale deployment/baserow -n baserow --replicas=1
+kubectl rollout status deployment/baserow -n baserow --timeout=10m
+```
+
+4. Verify the app:
+
+```bash
+kubectl run -n baserow baserow-curl --rm -i --restart=Never \
+  --image=curlimages/curl:8.8.0 -- \
+  sh -ceu 'curl -fsS -H "Host: relationships.thekeepstudios.com" -H "X-Forwarded-Proto: https" http://baserow/ | head'
+```
+
+## Gaps
+
+This MVP stores backups on-cluster. Off-cluster replication is still required
+for real disaster recovery.

--- a/kubernetes/apps/baserow/backup-cronjob.yaml
+++ b/kubernetes/apps/baserow/backup-cronjob.yaml
@@ -1,0 +1,179 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: baserow-backup-pvc
+  namespace: baserow
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: baserow-backup
+  namespace: baserow
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: baserow-backup
+  namespace: baserow
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments/scale
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: baserow-backup
+  namespace: baserow
+subjects:
+- kind: ServiceAccount
+  name: baserow-backup
+  namespace: baserow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: baserow-backup
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: baserow-backup
+  namespace: baserow
+spec:
+  schedule: "15 8 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: baserow-backup
+          terminationGracePeriodSeconds: 60
+          restartPolicy: OnFailure
+          containers:
+          - name: backup
+            image: baserow/baserow:2.2.2
+            imagePullPolicy: IfNotPresent
+            command:
+            - python
+            - -u
+            - -c
+            - |
+              import datetime
+              import json
+              import os
+              import signal
+              import ssl
+              import sys
+              import tarfile
+              import time
+              import urllib.parse
+              import urllib.request
+
+              namespace = "baserow"
+              deployment = "baserow"
+              api_host = "https://kubernetes.default.svc"
+              token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+              ca_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+              token = open(token_path, encoding="utf-8").read().strip()
+              context = ssl.create_default_context(cafile=ca_path)
+
+              def request(path, method="GET", body=None, content_type="application/json"):
+                  data = None if body is None else json.dumps(body).encode("utf-8")
+                  headers = {"Authorization": f"Bearer {token}"}
+                  if data is not None:
+                      headers["Content-Type"] = content_type
+                  req = urllib.request.Request(
+                      f"{api_host}{path}",
+                      data=data,
+                      headers=headers,
+                      method=method,
+                  )
+                  with urllib.request.urlopen(req, context=context, timeout=30) as response:
+                      raw = response.read()
+                  return json.loads(raw.decode("utf-8")) if raw else {}
+
+              def scale(replicas):
+                  request(
+                      f"/apis/apps/v1/namespaces/{namespace}/deployments/{deployment}/scale",
+                      method="PATCH",
+                      body={"spec": {"replicas": replicas}},
+                      content_type="application/merge-patch+json",
+                  )
+
+              def baserow_pods():
+                  selector = urllib.parse.quote("app=baserow")
+                  return request(f"/api/v1/namespaces/{namespace}/pods?labelSelector={selector}").get("items", [])
+
+              def restore_and_exit(signum, _frame):
+                  scale(1)
+                  sys.exit(128 + signum)
+
+              signal.signal(signal.SIGTERM, restore_and_exit)
+              signal.signal(signal.SIGINT, restore_and_exit)
+
+              try:
+                  scale(0)
+                  deadline = time.time() + 600
+                  while baserow_pods():
+                      if time.time() > deadline:
+                          raise TimeoutError("Timed out waiting for Baserow pod deletion before backup")
+                      time.sleep(5)
+
+                  timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+                  output = f"/backup/baserow_data_{timestamp}.tar.gz"
+                  with tarfile.open(output, "w:gz") as archive:
+                      archive.add("/baserow/data", arcname="data")
+                  if os.path.getsize(output) == 0:
+                      raise RuntimeError(f"Backup archive is empty: {output}")
+
+                  cutoff = time.time() - (14 * 24 * 60 * 60)
+                  for filename in os.listdir("/backup"):
+                      path = os.path.join("/backup", filename)
+                      if filename.startswith("baserow_data_") and filename.endswith(".tar.gz"):
+                          if os.path.isfile(path) and os.path.getmtime(path) < cutoff:
+                              os.remove(path)
+                  print(f"created {output}")
+              finally:
+                  scale(1)
+            volumeMounts:
+            - name: baserow-data
+              mountPath: /baserow/data
+              readOnly: true
+            - name: backup-data
+              mountPath: /backup
+            resources:
+              requests:
+                cpu: "50m"
+                memory: "128Mi"
+              limits:
+                cpu: "500m"
+                memory: "512Mi"
+          volumes:
+          - name: baserow-data
+            persistentVolumeClaim:
+              claimName: baserow-data
+              readOnly: true
+          - name: backup-data
+            persistentVolumeClaim:
+              claimName: baserow-backup-pvc

--- a/kubernetes/apps/baserow/kustomization.yaml
+++ b/kubernetes/apps/baserow/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- production.yaml
+- backup-cronjob.yaml

--- a/kubernetes/apps/baserow/production.yaml
+++ b/kubernetes/apps/baserow/production.yaml
@@ -1,0 +1,137 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: baserow
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: baserow-data
+  namespace: baserow
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baserow
+  namespace: baserow
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: baserow
+  template:
+    metadata:
+      labels:
+        app: baserow
+    spec:
+      containers:
+      - name: baserow
+        image: baserow/baserow:2.2.2
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: BASEROW_PUBLIC_URL
+          value: https://relationships.thekeepstudios.com
+        - name: BASEROW_RUN_MINIMAL
+          value: "yes"
+        - name: BASEROW_AMOUNT_OF_WORKERS
+          value: "1"
+        - name: BASEROW_AMOUNT_OF_GUNICORN_WORKERS
+          value: "2"
+        ports:
+        - name: http
+          containerPort: 80
+        - name: https
+          containerPort: 443
+        startupProbe:
+          httpGet:
+            path: /api/_health/
+            port: http
+            httpHeaders:
+            - name: Host
+              value: relationships.thekeepstudios.com
+            - name: X-Forwarded-Proto
+              value: https
+          failureThreshold: 60
+          periodSeconds: 10
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /api/_health/
+            port: http
+            httpHeaders:
+            - name: Host
+              value: relationships.thekeepstudios.com
+            - name: X-Forwarded-Proto
+              value: https
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 4
+        livenessProbe:
+          httpGet:
+            path: /api/_health/
+            port: http
+            httpHeaders:
+            - name: Host
+              value: relationships.thekeepstudios.com
+            - name: X-Forwarded-Proto
+              value: https
+          periodSeconds: 30
+          timeoutSeconds: 15
+          failureThreshold: 4
+        volumeMounts:
+        - name: data
+          mountPath: /baserow/data
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "2000m"
+            memory: "4Gi"
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: baserow-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: baserow
+  namespace: baserow
+spec:
+  type: ClusterIP
+  selector:
+    app: baserow
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: baserow-ingress
+  namespace: baserow
+  annotations:
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  rules:
+  - host: relationships.thekeepstudios.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: baserow
+            port:
+              number: 80

--- a/kubernetes/apps/baserow/secret.example.yaml
+++ b/kubernetes/apps/baserow/secret.example.yaml
@@ -1,0 +1,15 @@
+# Example only. Do not include this file in kustomization.yaml and do not apply
+# it without replacing every value. The MVP all-in-one deployment does not need
+# production secrets, but these are the likely variables if Baserow is later
+# moved to external PostgreSQL, external Redis, or SMTP.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: baserow-secrets
+  namespace: baserow
+type: Opaque
+stringData:
+  SECRET_KEY: "CHANGE_ME"
+  DATABASE_PASSWORD: "CHANGE_ME"
+  REDIS_PASSWORD: "CHANGE_ME"
+  EMAIL_SMTP_PASSWORD: "CHANGE_ME"

--- a/kubernetes/apps/espocrm/backup-cronjob.yaml
+++ b/kubernetes/apps/espocrm/backup-cronjob.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: espocrm-backup-pvc
+  namespace: espocrm
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: espocrm-backup
+  namespace: espocrm
+spec:
+  schedule: "42 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: backup
+            image: mariadb:11.8.6-ubi9
+            imagePullPolicy: IfNotPresent
+            env:
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: espocrm-secrets
+                  key: MARIADB_PASSWORD
+            command:
+            - sh
+            - -ceu
+            - |
+              ts="$(date -u +%Y%m%dT%H%M%SZ)"
+              mkdir -p /backup
+              mariadb-dump -h espocrm-db -u espocrm "-p${MARIADB_PASSWORD}" --single-transaction espocrm | gzip > "/backup/espocrm_db_${ts}.sql.gz"
+              tar -czf "/backup/espocrm_app_data_${ts}.tar.gz" -C /source espocrm-data
+              find /backup -type f -name 'espocrm_*' -mtime +14 -delete
+              ls -lah /backup
+            volumeMounts:
+            - name: backup-data
+              mountPath: /backup
+            - name: app-data
+              mountPath: /source/espocrm-data
+              readOnly: true
+            resources:
+              requests:
+                cpu: "100m"
+                memory: "256Mi"
+              limits:
+                cpu: "1000m"
+                memory: "1Gi"
+          volumes:
+          - name: backup-data
+            persistentVolumeClaim:
+              claimName: espocrm-backup-pvc
+          - name: app-data
+            persistentVolumeClaim:
+              claimName: espocrm-data

--- a/kubernetes/apps/espocrm/kustomization.yaml
+++ b/kubernetes/apps/espocrm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- production.yaml
+- backup-cronjob.yaml

--- a/kubernetes/apps/espocrm/production.yaml
+++ b/kubernetes/apps/espocrm/production.yaml
@@ -1,0 +1,275 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: espocrm
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: espocrm-db-data
+  namespace: espocrm
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: espocrm-data
+  namespace: espocrm
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: espocrm-db
+  namespace: espocrm
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: espocrm-db
+  template:
+    metadata:
+      labels:
+        app: espocrm-db
+    spec:
+      containers:
+      - name: mariadb
+        image: mariadb:11.8.6-ubi9
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: MARIADB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-secrets
+              key: MARIADB_ROOT_PASSWORD
+        - name: MARIADB_DATABASE
+          value: espocrm
+        - name: MARIADB_USER
+          value: espocrm
+        - name: MARIADB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-secrets
+              key: MARIADB_PASSWORD
+        ports:
+        - name: mysql
+          containerPort: 3306
+        readinessProbe:
+          exec:
+            command:
+            - healthcheck.sh
+            - --connect
+            - --innodb_initialized
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 12
+        livenessProbe:
+          exec:
+            command:
+            - healthcheck.sh
+            - --connect
+            - --innodb_initialized
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 6
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1Gi"
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: espocrm-db-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: espocrm-db
+  namespace: espocrm
+spec:
+  type: ClusterIP
+  selector:
+    app: espocrm-db
+  ports:
+  - name: mysql
+    port: 3306
+    targetPort: mysql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: espocrm
+  namespace: espocrm
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: espocrm
+      component: web
+  template:
+    metadata:
+      labels:
+        app: espocrm
+        component: web
+    spec:
+      containers:
+      - name: espocrm
+        image: espocrm/espocrm:9.3.8
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: ESPOCRM_DATABASE_PLATFORM
+          value: Mysql
+        - name: ESPOCRM_DATABASE_HOST
+          value: espocrm-db
+        - name: ESPOCRM_DATABASE_NAME
+          value: espocrm
+        - name: ESPOCRM_DATABASE_USER
+          value: espocrm
+        - name: ESPOCRM_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-secrets
+              key: MARIADB_PASSWORD
+        - name: ESPOCRM_ADMIN_USERNAME
+          value: admin
+        - name: ESPOCRM_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-secrets
+              key: ESPOCRM_ADMIN_PASSWORD
+        - name: ESPOCRM_SITE_URL
+          value: "https://espocrm.thekeepstudios.com"
+        ports:
+        - name: http
+          containerPort: 80
+        startupProbe:
+          httpGet:
+            path: /
+            port: http
+          failureThreshold: 60
+          periodSeconds: 10
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 4
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          periodSeconds: 30
+          timeoutSeconds: 15
+          failureThreshold: 4
+        volumeMounts:
+        - name: data
+          mountPath: /var/www/html
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "2000m"
+            memory: "2Gi"
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: espocrm-data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: espocrm-daemon
+  namespace: espocrm
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: espocrm
+      component: daemon
+  template:
+    metadata:
+      labels:
+        app: espocrm
+        component: daemon
+    spec:
+      containers:
+      - name: espocrm-daemon
+        image: espocrm/espocrm:9.3.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - docker-daemon.sh
+        volumeMounts:
+        - name: data
+          mountPath: /var/www/html
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1Gi"
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: espocrm-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: espocrm
+  namespace: espocrm
+spec:
+  type: ClusterIP
+  selector:
+    app: espocrm
+    component: web
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: espocrm-ingress
+  namespace: espocrm
+  annotations:
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  rules:
+  - host: espocrm.thekeepstudios.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: espocrm
+            port:
+              number: 80

--- a/kubernetes/apps/espocrm/secret.example.yaml
+++ b/kubernetes/apps/espocrm/secret.example.yaml
@@ -1,0 +1,13 @@
+# Example only. Do not include this file in kustomization.yaml and do not apply
+# it without replacing every value. Production/trial secrets are normally
+# created by Ansible from production_vars.yml.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: espocrm-secrets
+  namespace: espocrm
+type: Opaque
+stringData:
+  MARIADB_ROOT_PASSWORD: "CHANGE_ME"
+  MARIADB_PASSWORD: "CHANGE_ME"
+  ESPOCRM_ADMIN_PASSWORD: "CHANGE_ME"

--- a/kubernetes/apps/optional-crm.README.md
+++ b/kubernetes/apps/optional-crm.README.md
@@ -1,0 +1,16 @@
+# Optional CRM Apps
+
+Twenty and EspoCRM are optional platform applications. They are kept in the
+repository so they can be trialed or enabled later without making either CRM a
+core platform dependency.
+
+Baserow remains the core relationship-management app for now.
+
+Rules for optional CRM apps:
+
+- Disabled by default in GitOps.
+- Enabled explicitly through Ansible variables.
+- Deployed in their own namespaces, `twenty` and `espocrm`.
+- Backed up by app-specific CronJobs before any shared or production trial.
+- No rescue, medical, adoption, private convention, or client data should be
+  imported until a CRM has been deliberately chosen for that data class.

--- a/kubernetes/apps/twenty/backup-cronjob.yaml
+++ b/kubernetes/apps/twenty/backup-cronjob.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: twenty-backup-pvc
+  namespace: twenty
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: twenty-backup
+  namespace: twenty
+spec:
+  schedule: "27 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: backup
+            image: postgres:16
+            imagePullPolicy: IfNotPresent
+            env:
+            - name: PGDATABASE
+              value: default
+            - name: PGHOST
+              value: twenty-postgres
+            - name: PGUSER
+              value: postgres
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: twenty-secrets
+                  key: PG_DATABASE_PASSWORD
+            command:
+            - sh
+            - -ceu
+            - |
+              ts="$(date -u +%Y%m%dT%H%M%SZ)"
+              mkdir -p /backup
+              pg_dump --clean --if-exists --no-owner --no-privileges | gzip > "/backup/twenty_db_${ts}.sql.gz"
+              tar -czf "/backup/twenty_local_storage_${ts}.tar.gz" -C /source local-storage
+              find /backup -type f -name 'twenty_*' -mtime +14 -delete
+              ls -lah /backup
+            volumeMounts:
+            - name: backup-data
+              mountPath: /backup
+            - name: local-storage
+              mountPath: /source/local-storage
+              readOnly: true
+            resources:
+              requests:
+                cpu: "100m"
+                memory: "256Mi"
+              limits:
+                cpu: "1000m"
+                memory: "1Gi"
+          volumes:
+          - name: backup-data
+            persistentVolumeClaim:
+              claimName: twenty-backup-pvc
+          - name: local-storage
+            persistentVolumeClaim:
+              claimName: twenty-server-local-data

--- a/kubernetes/apps/twenty/kustomization.yaml
+++ b/kubernetes/apps/twenty/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- production.yaml
+- backup-cronjob.yaml

--- a/kubernetes/apps/twenty/production.yaml
+++ b/kubernetes/apps/twenty/production.yaml
@@ -1,0 +1,381 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: twenty
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: twenty-config
+  namespace: twenty
+data:
+  SERVER_URL: "https://twenty.thekeepstudios.com"
+  STORAGE_TYPE: "local"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: twenty-postgres-data
+  namespace: twenty
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: twenty-server-local-data
+  namespace: twenty
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: twenty-postgres
+  namespace: twenty
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: twenty-postgres
+  template:
+    metadata:
+      labels:
+        app: twenty-postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: POSTGRES_DB
+          value: default
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: twenty-secrets
+              key: PG_DATABASE_PASSWORD
+        ports:
+        - name: postgres
+          containerPort: 5432
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -ceu
+            - pg_isready -U postgres -d default
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -ceu
+            - pg_isready -U postgres -d default
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 6
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1Gi"
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: twenty-postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: twenty-postgres
+  namespace: twenty
+spec:
+  type: ClusterIP
+  selector:
+    app: twenty-postgres
+  ports:
+  - name: postgres
+    port: 5432
+    targetPort: postgres
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: twenty-redis
+  namespace: twenty
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: twenty-redis
+  template:
+    metadata:
+      labels:
+        app: twenty-redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:7.4-alpine
+        imagePullPolicy: IfNotPresent
+        args:
+        - --maxmemory-policy
+        - noeviction
+        ports:
+        - name: redis
+          containerPort: 6379
+        readinessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+        livenessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 6
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: twenty-redis
+  namespace: twenty
+spec:
+  type: ClusterIP
+  selector:
+    app: twenty-redis
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: twenty-server
+  namespace: twenty
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: twenty-server
+  template:
+    metadata:
+      labels:
+        app: twenty-server
+    spec:
+      containers:
+      - name: twenty
+        image: twentycrm/twenty:v2.4.0
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NODE_PORT
+          value: "3000"
+        - name: PG_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: twenty-secrets
+              key: PG_DATABASE_PASSWORD
+        - name: PG_DATABASE_URL
+          value: "postgres://postgres:$(PG_DATABASE_PASSWORD)@twenty-postgres:5432/default"
+        - name: SERVER_URL
+          valueFrom:
+            configMapKeyRef:
+              name: twenty-config
+              key: SERVER_URL
+        - name: REDIS_URL
+          value: redis://twenty-redis:6379
+        - name: STORAGE_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: twenty-config
+              key: STORAGE_TYPE
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: twenty-secrets
+              key: ENCRYPTION_KEY
+        - name: APP_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: twenty-secrets
+              key: APP_SECRET
+        ports:
+        - name: http
+          containerPort: 3000
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          failureThreshold: 60
+          periodSeconds: 10
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 4
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          periodSeconds: 30
+          timeoutSeconds: 15
+          failureThreshold: 4
+        volumeMounts:
+        - name: local-storage
+          mountPath: /app/packages/twenty-server/.local-storage
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "2000m"
+            memory: "2Gi"
+      volumes:
+      - name: local-storage
+        persistentVolumeClaim:
+          claimName: twenty-server-local-data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: twenty-worker
+  namespace: twenty
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: twenty-worker
+  template:
+    metadata:
+      labels:
+        app: twenty-worker
+    spec:
+      containers:
+      - name: twenty
+        image: twentycrm/twenty:v2.4.0
+        imagePullPolicy: IfNotPresent
+        command:
+        - yarn
+        - worker:prod
+        env:
+        - name: PG_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: twenty-secrets
+              key: PG_DATABASE_PASSWORD
+        - name: PG_DATABASE_URL
+          value: "postgres://postgres:$(PG_DATABASE_PASSWORD)@twenty-postgres:5432/default"
+        - name: SERVER_URL
+          valueFrom:
+            configMapKeyRef:
+              name: twenty-config
+              key: SERVER_URL
+        - name: REDIS_URL
+          value: redis://twenty-redis:6379
+        - name: DISABLE_DB_MIGRATIONS
+          value: "true"
+        - name: DISABLE_CRON_JOBS_REGISTRATION
+          value: "true"
+        - name: STORAGE_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: twenty-config
+              key: STORAGE_TYPE
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: twenty-secrets
+              key: ENCRYPTION_KEY
+        - name: APP_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: twenty-secrets
+              key: APP_SECRET
+        volumeMounts:
+        - name: local-storage
+          mountPath: /app/packages/twenty-server/.local-storage
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "2000m"
+            memory: "2Gi"
+      volumes:
+      - name: local-storage
+        persistentVolumeClaim:
+          claimName: twenty-server-local-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: twenty
+  namespace: twenty
+spec:
+  type: ClusterIP
+  selector:
+    app: twenty-server
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: twenty-ingress
+  namespace: twenty
+  annotations:
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  rules:
+  - host: twenty.thekeepstudios.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: twenty
+            port:
+              number: 80

--- a/kubernetes/apps/twenty/secret.example.yaml
+++ b/kubernetes/apps/twenty/secret.example.yaml
@@ -1,0 +1,13 @@
+# Example only. Do not include this file in kustomization.yaml and do not apply
+# it without replacing every value. Production/trial secrets are normally
+# created by Ansible from production_vars.yml.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: twenty-secrets
+  namespace: twenty
+type: Opaque
+stringData:
+  PG_DATABASE_PASSWORD: "CHANGE_ME"
+  ENCRYPTION_KEY: "CHANGE_ME"
+  APP_SECRET: "CHANGE_ME"

--- a/kubernetes/gitops/apps/platform-applications.yaml
+++ b/kubernetes/gitops/apps/platform-applications.yaml
@@ -88,6 +88,28 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  name: platform-baserow
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: "https://github.com/The-Keep-Studios/thekeep-platform.git"
+    targetRevision: "main"
+    path: kubernetes/apps/baserow
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: baserow
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
   name: platform-monitoring-prometheus
   namespace: argocd
 spec:

--- a/kubernetes/gitops/templates/platform-applications.yaml
+++ b/kubernetes/gitops/templates/platform-applications.yaml
@@ -88,6 +88,28 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  name: platform-baserow
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: "{{ gitops_repo_url }}"
+    targetRevision: "{{ gitops_revision }}"
+    path: kubernetes/apps/baserow
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: baserow
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
   name: platform-monitoring-prometheus
   namespace: argocd
 spec:

--- a/kubernetes/gitops/templates/platform-applications.yaml
+++ b/kubernetes/gitops/templates/platform-applications.yaml
@@ -40,6 +40,54 @@ spec:
     syncOptions:
     - CreateNamespace=true
     - ServerSideApply=true
+{% if ((platform_optional_apps | default({})).twenty | default({})).enabled | default(false) | bool %}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: platform-crm-twenty
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: "{{ gitops_repo_url }}"
+    targetRevision: "{{ gitops_revision }}"
+    path: kubernetes/apps/twenty
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: twenty
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true
+{% endif %}
+{% if ((platform_optional_apps | default({})).espocrm | default({})).enabled | default(false) | bool %}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: platform-crm-espocrm
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: "{{ gitops_repo_url }}"
+    targetRevision: "{{ gitops_revision }}"
+    path: kubernetes/apps/espocrm
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: espocrm
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true
+{% endif %}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/kubernetes/platform/monitoring/access/baserow-logs-dashboard.yaml
+++ b/kubernetes/platform/monitoring/access/baserow-logs-dashboard.yaml
@@ -1,0 +1,210 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: baserow-logs-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  baserow-logs.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "{namespace=\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |~ \"$search\"",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Baserow Logs",
+          "type": "logs"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 11
+          },
+          "id": 2,
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": true,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "{namespace=\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |~ \"(?i)(500|error|exception|failed|warning|backup|healthcheck|migration)\" |~ \"$search\"",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Baserow Errors and Backup Events",
+          "type": "logs"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": [
+        "baserow",
+        "logs",
+        "loki",
+        "relationship-os"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Loki",
+              "value": "Loki"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Loki Datasource",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "loki",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "baserow",
+              "value": "baserow"
+            },
+            "hide": 0,
+            "label": "Namespace",
+            "name": "namespace",
+            "options": [],
+            "query": "baserow",
+            "skipUrlSync": false,
+            "type": "textbox"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "baserow-.*",
+              "value": "baserow-.*"
+            },
+            "hide": 0,
+            "label": "Pod Regex",
+            "name": "pod",
+            "options": [],
+            "query": "baserow-.*",
+            "skipUrlSync": false,
+            "type": "textbox"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "baserow|backup",
+              "value": "baserow|backup"
+            },
+            "hide": 0,
+            "label": "Container Regex",
+            "name": "container",
+            "options": [],
+            "query": "baserow|backup",
+            "skipUrlSync": false,
+            "type": "textbox"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": ".*",
+              "value": ".*"
+            },
+            "hide": 0,
+            "label": "Search Regex",
+            "name": "search",
+            "options": [],
+            "query": ".*",
+            "skipUrlSync": false,
+            "type": "textbox"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-2h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Baserow Logs",
+      "uid": "baserow-logs",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/kubernetes/platform/monitoring/access/kustomization.yaml
+++ b/kubernetes/platform/monitoring/access/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- middleware.yaml
+- leantime-logs-dashboard.yaml
+- baserow-logs-dashboard.yaml

--- a/kubernetes/platform/monitoring/kube-prometheus-stack.values.yaml
+++ b/kubernetes/platform/monitoring/kube-prometheus-stack.values.yaml
@@ -72,6 +72,14 @@ additionalPrometheusRulesMap:
             annotations:
               summary: "Leantime database backup failed"
               description: "The Leantime database backup job {{ $labels.job_name }} has failed."
+          - alert: BaserowBackupFailed
+            expr: kube_job_status_failed{namespace="baserow", job_name=~"baserow-backup-.*"} > 0
+            for: 0m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Baserow data backup failed"
+              description: "The Baserow backup job {{ $labels.job_name }} has failed."
   platform-visibility-rules:
     groups:
       - name: platform.visibility.rules
@@ -84,6 +92,14 @@ additionalPrometheusRulesMap:
             annotations:
               summary: "WiseMapping backend is unavailable"
               description: "The WiseMapping deployment has fewer available replicas than desired. The nginx frontend may still answer / while the Java API is down."
+          - alert: BaserowUnavailable
+            expr: kube_deployment_status_replicas_available{namespace="baserow", deployment="baserow"} < kube_deployment_spec_replicas{namespace="baserow", deployment="baserow"}
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Baserow is unavailable"
+              description: "The Baserow deployment has fewer available replicas than desired."
           - alert: GrafanaUnavailable
             expr: kube_deployment_status_replicas_available{namespace="monitoring", deployment="kube-prometheus-stack-grafana"} < kube_deployment_spec_replicas{namespace="monitoring", deployment="kube-prometheus-stack-grafana"}
             for: 5m

--- a/scripts/dev-baserow-observe.sh
+++ b/scripts/dev-baserow-observe.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/dev-observe.sh" baserow "$@"

--- a/scripts/dev-baserow-smoke.sh
+++ b/scripts/dev-baserow-smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/dev-smoke.sh" baserow "$@"

--- a/scripts/dev-crm-bakeoff-observe.sh
+++ b/scripts/dev-crm-bakeoff-observe.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/dev-observe.sh" optional-crm "$@"

--- a/scripts/dev-crm-bakeoff-smoke.sh
+++ b/scripts/dev-crm-bakeoff-smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/dev-smoke.sh" optional-crm "$@"

--- a/scripts/dev-espocrm-observe.sh
+++ b/scripts/dev-espocrm-observe.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/dev-observe.sh" espocrm "$@"

--- a/scripts/dev-espocrm-smoke.sh
+++ b/scripts/dev-espocrm-smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/dev-smoke.sh" espocrm "$@"

--- a/scripts/dev-observe.sh
+++ b/scripts/dev-observe.sh
@@ -91,9 +91,29 @@ app_config() {
       APP_PROBE_PATTERN="login|sign|create account"
       APP_CONFIG_KIND="baserow"
       ;;
+    twenty)
+      APP_NAMESPACE="twenty"
+      APP_SERVICE="twenty"
+      APP_DEPLOYMENT="twenty-server"
+      APP_PORT="${TWENTY_OBSERVE_PORT:-18083}"
+      APP_HOST="${TWENTY_PROBE_HOST:-twenty.thekeepstudios.com}"
+      APP_PROBE_PATH="/"
+      APP_PROBE_PATTERN="twenty|login|sign|workspace"
+      APP_CONFIG_KIND="twenty"
+      ;;
+    espocrm)
+      APP_NAMESPACE="espocrm"
+      APP_SERVICE="espocrm"
+      APP_DEPLOYMENT="espocrm"
+      APP_PORT="${ESPOCRM_OBSERVE_PORT:-18084}"
+      APP_HOST="${ESPOCRM_PROBE_HOST:-espocrm.thekeepstudios.com}"
+      APP_PROBE_PATH="/"
+      APP_PROBE_PATTERN="espocrm|login|username|password"
+      APP_CONFIG_KIND="espocrm"
+      ;;
     *)
       echo "Unknown dev observe target: ${target}" >&2
-      echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|platform]" >&2
+      echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform]" >&2
       return 2
       ;;
   esac
@@ -146,6 +166,30 @@ patch_local_config() {
         --type=json \
         -p "[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/startupProbe/httpGet/httpHeaders/0/value\",\"value\":\"${APP_HOST}\"},{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/readinessProbe/httpGet/httpHeaders/0/value\",\"value\":\"${APP_HOST}\"},{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/livenessProbe/httpGet/httpHeaders/0/value\",\"value\":\"${APP_HOST}\"}]"
       kubectl rollout status "deployment/${APP_DEPLOYMENT}" -n "${APP_NAMESPACE}" --timeout=10m
+      ;;
+    twenty)
+      local_base_url="http://127.0.0.1:${APP_PORT}"
+      APP_HOST="127.0.0.1:${APP_PORT}"
+      echo "Patching local Twenty SERVER_URL for browser observation: ${local_base_url}"
+      kubectl get configmap twenty-config -n "${APP_NAMESPACE}" \
+        -o yaml > "${artifact_dir}/twenty-config.original.yaml"
+      kubectl patch configmap twenty-config -n "${APP_NAMESPACE}" \
+        --type merge \
+        -p "{\"data\":{\"SERVER_URL\":\"${local_base_url}\"}}"
+      kubectl rollout restart deployment/twenty-server -n "${APP_NAMESPACE}"
+      kubectl rollout restart deployment/twenty-worker -n "${APP_NAMESPACE}"
+      kubectl rollout status deployment/twenty-server -n "${APP_NAMESPACE}" --timeout=10m
+      kubectl rollout status deployment/twenty-worker -n "${APP_NAMESPACE}" --timeout=10m
+      ;;
+    espocrm)
+      local_base_url="http://127.0.0.1:${APP_PORT}"
+      APP_HOST="127.0.0.1:${APP_PORT}"
+      echo "Patching local EspoCRM site URL for browser observation: ${local_base_url}"
+      kubectl get deployment espocrm -n "${APP_NAMESPACE}" \
+        -o yaml > "${artifact_dir}/espocrm-deployment.original.yaml"
+      kubectl set env deployment/espocrm -n "${APP_NAMESPACE}" \
+        ESPOCRM_SITE_URL="${local_base_url}"
+      kubectl rollout status deployment/espocrm -n "${APP_NAMESPACE}" --timeout=10m
       ;;
   esac
 }
@@ -256,7 +300,7 @@ observe_one() {
 
   local_url="http://127.0.0.1:${APP_PORT}/"
   human_url="http://localhost:${APP_PORT}/"
-  if [ "${APP_CONFIG_KIND}" = "baserow" ]; then
+  if [ "${APP_CONFIG_KIND}" = "baserow" ] || [ "${APP_CONFIG_KIND}" = "twenty" ] || [ "${APP_CONFIG_KIND}" = "espocrm" ]; then
     human_url="${local_url}"
   fi
 
@@ -309,9 +353,11 @@ main() {
     case "${target}" in
       platform|wisemapping|leantime|baserow)
         ;;
+      twenty|espocrm|optional-crm|crm-bakeoff)
+        ;;
       *)
         echo "Unknown dev observe target: ${target}" >&2
-        echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|platform]" >&2
+        echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform]" >&2
         exit 2
         ;;
     esac
@@ -327,12 +373,16 @@ main() {
         observe_one leantime
         observe_one baserow
         ;;
-      wisemapping|leantime|baserow)
+      optional-crm|crm-bakeoff)
+        observe_one twenty
+        observe_one espocrm
+        ;;
+      wisemapping|leantime|baserow|twenty|espocrm)
         observe_one "${target}"
         ;;
       *)
         echo "Unknown dev observe target: ${target}" >&2
-        echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|platform]" >&2
+        echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform]" >&2
         exit 2
         ;;
     esac

--- a/scripts/dev-observe.sh
+++ b/scripts/dev-observe.sh
@@ -81,9 +81,19 @@ app_config() {
       APP_PROBE_PATTERN="leantime|login|email|password|install|redirecting"
       APP_CONFIG_KIND="leantime"
       ;;
+    baserow)
+      APP_NAMESPACE="baserow"
+      APP_SERVICE="baserow"
+      APP_DEPLOYMENT="baserow"
+      APP_PORT="${BASEROW_OBSERVE_PORT:-18082}"
+      APP_HOST="${BASEROW_PROBE_HOST:-relationships.thekeepstudios.com}"
+      APP_PROBE_PATH="/"
+      APP_PROBE_PATTERN="login|sign|create account"
+      APP_CONFIG_KIND="baserow"
+      ;;
     *)
       echo "Unknown dev observe target: ${target}" >&2
-      echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|platform]" >&2
+      echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|platform]" >&2
       return 2
       ;;
   esac
@@ -122,6 +132,19 @@ patch_local_config() {
         --type merge \
         -p "{\"data\":{\"LEAN_APP_URL\":\"${local_base_url}\"}}"
       kubectl rollout restart "deployment/${APP_DEPLOYMENT}" -n "${APP_NAMESPACE}"
+      kubectl rollout status "deployment/${APP_DEPLOYMENT}" -n "${APP_NAMESPACE}" --timeout=10m
+      ;;
+    baserow)
+      local_base_url="http://127.0.0.1:${APP_PORT}"
+      APP_HOST="127.0.0.1:${APP_PORT}"
+      echo "Patching local Baserow public URL for browser observation: ${local_base_url}"
+      kubectl get deployment baserow -n "${APP_NAMESPACE}" \
+        -o yaml > "${artifact_dir}/baserow-deployment.original.yaml"
+      kubectl set env "deployment/${APP_DEPLOYMENT}" -n "${APP_NAMESPACE}" \
+        BASEROW_PUBLIC_URL="${local_base_url}"
+      kubectl patch "deployment/${APP_DEPLOYMENT}" -n "${APP_NAMESPACE}" \
+        --type=json \
+        -p "[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/startupProbe/httpGet/httpHeaders/0/value\",\"value\":\"${APP_HOST}\"},{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/readinessProbe/httpGet/httpHeaders/0/value\",\"value\":\"${APP_HOST}\"},{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/livenessProbe/httpGet/httpHeaders/0/value\",\"value\":\"${APP_HOST}\"}]"
       kubectl rollout status "deployment/${APP_DEPLOYMENT}" -n "${APP_NAMESPACE}" --timeout=10m
       ;;
   esac
@@ -233,6 +256,9 @@ observe_one() {
 
   local_url="http://127.0.0.1:${APP_PORT}/"
   human_url="http://localhost:${APP_PORT}/"
+  if [ "${APP_CONFIG_KIND}" = "baserow" ]; then
+    human_url="${local_url}"
+  fi
 
   cat > "${artifact_dir}/README.txt" <<EOF
 ${target} local observation
@@ -281,11 +307,11 @@ main() {
 
   for target in "${targets[@]}"; do
     case "${target}" in
-      platform|wisemapping|leantime)
+      platform|wisemapping|leantime|baserow)
         ;;
       *)
         echo "Unknown dev observe target: ${target}" >&2
-        echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|platform]" >&2
+        echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|platform]" >&2
         exit 2
         ;;
     esac
@@ -299,13 +325,14 @@ main() {
       platform)
         observe_one wisemapping
         observe_one leantime
+        observe_one baserow
         ;;
-      wisemapping|leantime)
+      wisemapping|leantime|baserow)
         observe_one "${target}"
         ;;
       *)
         echo "Unknown dev observe target: ${target}" >&2
-        echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|platform]" >&2
+        echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|platform]" >&2
         exit 2
         ;;
     esac

--- a/scripts/dev-optional-crm-observe.sh
+++ b/scripts/dev-optional-crm-observe.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/dev-observe.sh" optional-crm "$@"

--- a/scripts/dev-optional-crm-smoke.sh
+++ b/scripts/dev-optional-crm-smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/dev-smoke.sh" optional-crm "$@"

--- a/scripts/dev-smoke.sh
+++ b/scripts/dev-smoke.sh
@@ -67,6 +67,18 @@ diagnostics_baserow() {
   kubectl logs deploy/baserow -n baserow --all-containers --tail=200 || true
 }
 
+diagnostics_optional_crm() {
+  kubectl get pods,deploy,svc,pvc,cronjob,ingress -n twenty || true
+  kubectl get pods,deploy,svc,pvc,cronjob,ingress -n espocrm || true
+  kubectl describe deploy/twenty-server -n twenty || true
+  kubectl describe deploy/twenty-worker -n twenty || true
+  kubectl describe deploy/espocrm -n espocrm || true
+  kubectl logs deploy/twenty-server -n twenty --all-containers --tail=200 || true
+  kubectl logs deploy/twenty-worker -n twenty --all-containers --tail=200 || true
+  kubectl logs deploy/espocrm -n espocrm --all-containers --tail=200 || true
+  kubectl logs deploy/espocrm-daemon -n espocrm --all-containers --tail=200 || true
+}
+
 smoke_wisemapping() {
   local probe_host="${WISEMAPPING_PROBE_HOST:-mindmaps.thekeepstudios.com}"
   local wait_timeout="${WISEMAPPING_WAIT_TIMEOUT:-${DEFAULT_WAIT_TIMEOUT}}"
@@ -199,6 +211,107 @@ smoke_baserow() {
   echo "Baserow smoke test passed"
 }
 
+smoke_twenty() {
+  local probe_host="${TWENTY_PROBE_HOST:-twenty.thekeepstudios.com}"
+  local wait_timeout="${TWENTY_WAIT_TIMEOUT:-20m}"
+  local pg_password="${TWENTY_DEV_PG_DATABASE_PASSWORD:-dev-twenty-postgres-password}"
+  local encryption_key="${TWENTY_DEV_ENCRYPTION_KEY:-dev-twenty-encryption-key-32chars}"
+  local app_secret="${TWENTY_DEV_APP_SECRET:-dev-twenty-app-secret-32chars}"
+  local probe_name
+  local probe_output
+
+  echo "== Twenty CRM smoke =="
+  kubectl create namespace twenty --dry-run=client -o yaml | kubectl apply -f -
+  kubectl create secret generic twenty-secrets -n twenty \
+    --from-literal=PG_DATABASE_PASSWORD="${pg_password}" \
+    --from-literal=ENCRYPTION_KEY="${encryption_key}" \
+    --from-literal=APP_SECRET="${app_secret}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  kubectl apply -k kubernetes/apps/twenty
+  kubectl rollout status deploy/twenty-postgres -n twenty --timeout="${wait_timeout}"
+  kubectl rollout status deploy/twenty-redis -n twenty --timeout="${wait_timeout}"
+  kubectl rollout status deploy/twenty-server -n twenty --timeout="${wait_timeout}"
+  kubectl rollout status deploy/twenty-worker -n twenty --timeout="${wait_timeout}"
+  assert_deployment_available twenty twenty-postgres
+  assert_deployment_available twenty twenty-redis
+  assert_deployment_available twenty twenty-server
+  assert_deployment_available twenty twenty-worker
+
+  probe_name="twenty-smoke-$(date +%s)"
+  probe_output="$(kubectl run -n twenty "${probe_name}" \
+    --rm=true \
+    --attach=true \
+    -i \
+    --restart=Never \
+    --image="${PROBE_IMAGE}" \
+    --quiet=true \
+    -- \
+    sh -ceu '
+      curl -fsS --max-time 20 http://twenty/healthz > /tmp/twenty-health.txt
+      curl -fsS --max-time 20 \
+        -H "Host: '"${probe_host}"'" \
+        -H "X-Forwarded-Proto: https" \
+        http://twenty/ > /tmp/twenty.html
+      test -s /tmp/twenty.html
+      grep -Eiq "twenty|login|sign|workspace" /tmp/twenty.html
+      head -c 500 /tmp/twenty.html
+    ' 2>&1)"
+  echo "${probe_output}"
+  grep -Eiq "twenty|login|sign|workspace" <<< "${probe_output}"
+
+  echo "Twenty CRM smoke test passed"
+}
+
+smoke_espocrm() {
+  local probe_host="${ESPOCRM_PROBE_HOST:-espocrm.thekeepstudios.com}"
+  local wait_timeout="${ESPOCRM_WAIT_TIMEOUT:-20m}"
+  local root_password="${ESPOCRM_DEV_DB_ROOT_PASSWORD:-dev-espocrm-root-password}"
+  local db_password="${ESPOCRM_DEV_DB_PASSWORD:-dev-espocrm-db-password}"
+  local admin_password="${ESPOCRM_DEV_ADMIN_PASSWORD:-dev-espocrm-admin-password}"
+  local probe_name
+  local probe_output
+
+  echo "== EspoCRM smoke =="
+  kubectl create namespace espocrm --dry-run=client -o yaml | kubectl apply -f -
+  kubectl create secret generic espocrm-secrets -n espocrm \
+    --from-literal=MARIADB_ROOT_PASSWORD="${root_password}" \
+    --from-literal=MARIADB_PASSWORD="${db_password}" \
+    --from-literal=ESPOCRM_ADMIN_PASSWORD="${admin_password}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  kubectl apply -k kubernetes/apps/espocrm
+  kubectl rollout status deploy/espocrm-db -n espocrm --timeout="${wait_timeout}"
+  kubectl rollout status deploy/espocrm -n espocrm --timeout="${wait_timeout}"
+  kubectl rollout status deploy/espocrm-daemon -n espocrm --timeout="${wait_timeout}"
+  assert_deployment_available espocrm espocrm-db
+  assert_deployment_available espocrm espocrm
+  assert_deployment_available espocrm espocrm-daemon
+
+  probe_name="espocrm-smoke-$(date +%s)"
+  probe_output="$(kubectl run -n espocrm "${probe_name}" \
+    --rm=true \
+    --attach=true \
+    -i \
+    --restart=Never \
+    --image="${PROBE_IMAGE}" \
+    --quiet=true \
+    -- \
+    sh -ceu '
+      curl -fsS --max-time 20 \
+        -H "Host: '"${probe_host}"'" \
+        -H "X-Forwarded-Proto: https" \
+        http://espocrm/ > /tmp/espocrm.html
+      test -s /tmp/espocrm.html
+      grep -Eiq "espocrm|login|username|password" /tmp/espocrm.html
+      head -c 500 /tmp/espocrm.html
+    ' 2>&1)"
+  echo "${probe_output}"
+  grep -Eiq "espocrm|login|username|password" <<< "${probe_output}"
+
+  echo "EspoCRM smoke test passed"
+}
+
 run_target() {
   local target="$1"
 
@@ -221,6 +334,22 @@ run_target() {
         return 1
       fi
       ;;
+    twenty)
+      if ! smoke_twenty; then
+        diagnostics_optional_crm
+        return 1
+      fi
+      ;;
+    espocrm)
+      if ! smoke_espocrm; then
+        diagnostics_optional_crm
+        return 1
+      fi
+      ;;
+    optional-crm|crm-bakeoff)
+      run_target twenty
+      run_target espocrm
+      ;;
     platform)
       run_target wisemapping
       run_target leantime
@@ -228,7 +357,7 @@ run_target() {
       ;;
     *)
       echo "Unknown dev smoke target: ${target}" >&2
-      echo "Usage: scripts/dev-smoke.sh [wisemapping|leantime|baserow|platform]..." >&2
+      echo "Usage: scripts/dev-smoke.sh [wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform]..." >&2
       return 2
       ;;
   esac
@@ -236,11 +365,11 @@ run_target() {
 
 validate_target() {
   case "$1" in
-    wisemapping|leantime|baserow|platform)
+    wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform)
       ;;
     *)
       echo "Unknown dev smoke target: $1" >&2
-      echo "Usage: scripts/dev-smoke.sh [wisemapping|leantime|baserow|platform]..." >&2
+      echo "Usage: scripts/dev-smoke.sh [wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform]..." >&2
       return 2
       ;;
   esac

--- a/scripts/dev-smoke.sh
+++ b/scripts/dev-smoke.sh
@@ -20,6 +20,18 @@ require_cmd() {
   fi
 }
 
+assert_deployment_available() {
+  local namespace="$1"
+  local deployment="$2"
+  local available
+
+  available="$(kubectl get "deployment/${deployment}" -n "${namespace}" -o jsonpath='{.status.availableReplicas}')"
+  if ! [[ "${available:-0}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Deployment ${namespace}/${deployment} is not available." >&2
+    return 1
+  fi
+}
+
 ensure_cluster() {
   require_cmd k3d
   require_cmd kubectl
@@ -49,6 +61,12 @@ diagnostics_leantime() {
   kubectl logs deploy/leantime-mariadb -n default --all-containers --tail=100 || true
 }
 
+diagnostics_baserow() {
+  kubectl get pods,deploy,svc,pvc,cronjob -n baserow || true
+  kubectl describe deploy/baserow -n baserow || true
+  kubectl logs deploy/baserow -n baserow --all-containers --tail=200 || true
+}
+
 smoke_wisemapping() {
   local probe_host="${WISEMAPPING_PROBE_HOST:-mindmaps.thekeepstudios.com}"
   local wait_timeout="${WISEMAPPING_WAIT_TIMEOUT:-${DEFAULT_WAIT_TIMEOUT}}"
@@ -56,6 +74,7 @@ smoke_wisemapping() {
   local dev_jwt_secret="${WISEMAPPING_DEV_JWT_SECRET:-dev-jwt-secret-not-for-production}"
   local dev_oauth_token_secret="${WISEMAPPING_DEV_OAUTH_TOKEN_SECRET:-dev-oauth-token-secret-not-for-production}"
   local probe_name
+  local probe_output
 
   echo "== WiseMapping smoke =="
   kubectl create namespace wisemapping --dry-run=client -o yaml | kubectl apply -f -
@@ -73,9 +92,11 @@ smoke_wisemapping() {
   kubectl apply -k kubernetes/apps/wisemapping
   kubectl rollout status deploy/wisemapping-postgres -n wisemapping --timeout="${wait_timeout}"
   kubectl rollout status deploy/wisemapping -n wisemapping --timeout="${wait_timeout}"
+  assert_deployment_available wisemapping wisemapping-postgres
+  assert_deployment_available wisemapping wisemapping
 
   probe_name="wisemapping-smoke-$(date +%s)"
-  kubectl run -n wisemapping "${probe_name}" \
+  probe_output="$(kubectl run -n wisemapping "${probe_name}" \
     --rm=true \
     --attach=true \
     -i \
@@ -91,7 +112,10 @@ smoke_wisemapping() {
       grep -q "apiBaseUrl" /tmp/wisemapping-config.json
       grep -q "uiBaseUrl" /tmp/wisemapping-config.json
       cat /tmp/wisemapping-config.json
-    '
+    ' 2>&1)"
+  echo "${probe_output}"
+  grep -q "apiBaseUrl" <<< "${probe_output}"
+  grep -q "uiBaseUrl" <<< "${probe_output}"
 
   echo "WiseMapping smoke test passed"
 }
@@ -102,6 +126,7 @@ smoke_leantime() {
   local root_password="${LEANTIME_DEV_DB_ROOT_PASSWORD:-dev-leantime-root-password-not-for-production}"
   local db_password="${LEANTIME_DEV_DB_PASSWORD:-dev-leantime-password-not-for-production}"
   local probe_name
+  local probe_output
 
   echo "== Leantime smoke =="
   kubectl create secret generic leantime-db -n default \
@@ -112,9 +137,11 @@ smoke_leantime() {
   kubectl apply -k kubernetes/apps/leantime
   kubectl rollout status deploy/leantime-mariadb -n default --timeout="${wait_timeout}"
   kubectl rollout status deploy/leantime -n default --timeout="${wait_timeout}"
+  assert_deployment_available default leantime-mariadb
+  assert_deployment_available default leantime
 
   probe_name="leantime-smoke-$(date +%s)"
-  kubectl run -n default "${probe_name}" \
+  probe_output="$(kubectl run -n default "${probe_name}" \
     --rm=true \
     --attach=true \
     -i \
@@ -130,9 +157,46 @@ smoke_leantime() {
       test -s /tmp/leantime-login.html
       grep -Eiq "leantime|login|email|password|install|redirecting" /tmp/leantime-login.html
       head -c 500 /tmp/leantime-login.html
-    '
+    ' 2>&1)"
+  echo "${probe_output}"
+  grep -Eiq "leantime|login|email|password|install|redirecting" <<< "${probe_output}"
 
   echo "Leantime smoke test passed"
+}
+
+smoke_baserow() {
+  local probe_host="${BASEROW_PROBE_HOST:-relationships.thekeepstudios.com}"
+  local wait_timeout="${BASEROW_WAIT_TIMEOUT:-${DEFAULT_WAIT_TIMEOUT}}"
+  local probe_name
+  local probe_output
+
+  echo "== Baserow smoke =="
+  kubectl apply -k kubernetes/apps/baserow
+  kubectl rollout status deploy/baserow -n baserow --timeout="${wait_timeout}"
+  assert_deployment_available baserow baserow
+
+  probe_name="baserow-smoke-$(date +%s)"
+  probe_output="$(kubectl run -n baserow "${probe_name}" \
+    --rm=true \
+    --attach=true \
+    -i \
+    --restart=Never \
+    --image="${PROBE_IMAGE}" \
+    --quiet=true \
+    -- \
+    sh -ceu '
+      curl -fsS --max-time 20 \
+        -H "Host: '"${probe_host}"'" \
+        -H "X-Forwarded-Proto: https" \
+        http://baserow/ > /tmp/baserow.html
+      test -s /tmp/baserow.html
+      grep -Eiq "baserow|login|sign" /tmp/baserow.html
+      head -c 500 /tmp/baserow.html
+    ' 2>&1)"
+  echo "${probe_output}"
+  grep -Eiq "login|sign|create account" <<< "${probe_output}"
+
+  echo "Baserow smoke test passed"
 }
 
 run_target() {
@@ -151,13 +215,20 @@ run_target() {
         return 1
       fi
       ;;
+    baserow)
+      if ! smoke_baserow; then
+        diagnostics_baserow
+        return 1
+      fi
+      ;;
     platform)
       run_target wisemapping
       run_target leantime
+      run_target baserow
       ;;
     *)
       echo "Unknown dev smoke target: ${target}" >&2
-      echo "Usage: scripts/dev-smoke.sh [wisemapping|leantime|platform]..." >&2
+      echo "Usage: scripts/dev-smoke.sh [wisemapping|leantime|baserow|platform]..." >&2
       return 2
       ;;
   esac
@@ -165,11 +236,11 @@ run_target() {
 
 validate_target() {
   case "$1" in
-    wisemapping|leantime|platform)
+    wisemapping|leantime|baserow|platform)
       ;;
     *)
       echo "Unknown dev smoke target: $1" >&2
-      echo "Usage: scripts/dev-smoke.sh [wisemapping|leantime|platform]..." >&2
+      echo "Usage: scripts/dev-smoke.sh [wisemapping|leantime|baserow|platform]..." >&2
       return 2
       ;;
   esac

--- a/scripts/dev-twenty-observe.sh
+++ b/scripts/dev-twenty-observe.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/dev-observe.sh" twenty "$@"

--- a/scripts/dev-twenty-smoke.sh
+++ b/scripts/dev-twenty-smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/dev-smoke.sh" twenty "$@"

--- a/scripts/production.env.example
+++ b/scripts/production.env.example
@@ -8,6 +8,7 @@ AUTHENTIK_URL=https://auth.thekeepstudios.com
 LEANTIME_URL=https://projects.thekeepstudios.com
 # GITLAB_URL=https://gitlab.thekeepstudios.com
 WISEMAPPING_URL=https://mindmaps.thekeepstudios.com
+BASEROW_URL=https://relationships.thekeepstudios.com
 
 # -----------------------------------------------------------------------------
 # Monitoring domains

--- a/scripts/validate-production-gate.sh
+++ b/scripts/validate-production-gate.sh
@@ -12,6 +12,7 @@ APP_NAMES=(
   platform-authentik
   platform-leantime
   platform-wisemapping
+  platform-baserow
   platform-monitoring-prometheus
   platform-monitoring-loki
 )
@@ -20,6 +21,7 @@ HTTPS_ENDPOINTS=(
   https://auth.thekeepstudios.com
   https://projects.thekeepstudios.com
   https://mindmaps.thekeepstudios.com
+  https://relationships.thekeepstudios.com
   https://grafana.thekeepstudios.com
   https://prometheus.thekeepstudios.com
   https://alerts.thekeepstudios.com
@@ -95,6 +97,12 @@ check_backup_resources() {
     pass "Leantime backup CronJob exists"
   else
     fail "Leantime backup CronJob is missing"
+  fi
+
+  if kadmin get cronjob baserow-backup -n baserow >/dev/null 2>&1; then
+    pass "Baserow backup CronJob exists"
+  else
+    fail "Baserow backup CronJob is missing"
   fi
 }
 


### PR DESCRIPTION
## Summary

Adds the Relationship OS foundation to the platform.

This PR includes the Baserow core app work and the `feature/optional-crm-apps` changes. Baserow remains the default/core relationship-management app. Twenty and EspoCRM are included as optional CRM candidates that are disabled by default and can be enabled explicitly for trials.

## Changes

- Add Baserow as the core relationship-management app.
- Add Baserow persistence, backup CronJob, smoke/observe scripts, and monitoring dashboard support.
- Add Relationship OS docs:
  - implementation plan
  - schema plan
  - data-boundary policy
  - GetBuddy diligence checklist
  - restore runbook
- Add Twenty as an optional CRM app.
- Add EspoCRM as an optional CRM app.
- Add optional CRM toggles via `platform_optional_apps`.
- Add optional CRM production secret validation.
- Add optional CRM Argo CD rendering only when enabled.
- Add optional CRM backup CronJobs.
- Extend local k3d smoke/observe tooling for Baserow, Twenty, EspoCRM, and `optional-crm`.

## Verification

- Ran static IaC validation with `scripts/test-iac-static.sh`.
- Verified GitOps template rendering:
  - default render does not include optional CRM apps
  - Twenty renders only when enabled
  - EspoCRM renders only when enabled
  - both can be enabled together
- Ran local smoke checks for Twenty and EspoCRM.
- Ran local observe checks for optional CRM apps.
- Triggered manual local backup Jobs for Twenty and EspoCRM and confirmed backup artifacts were created.

## Notes

Baserow is the only core app added by this PR. Twenty and EspoCRM are kept as optional trial apps, not selected production systems.

Sensitive relationship, rescue, medical, adoption, private convention, or client data should not be imported into optional CRM apps until a tool is deliberately selected for that data class.