### PR TITLE
Upgrade Leantime to 3.8.0

### DIFF
--- a/kubernetes/apps/leantime/demo-standalone.yaml
+++ b/kubernetes/apps/leantime/demo-standalone.yaml
@@ -208,7 +208,7 @@ spec:
           done
       containers:
       - name: leantime
-        image: leantime/leantime:3.7.3
+        image: leantime/leantime:3.8.0
         imagePullPolicy: IfNotPresent
         envFrom:
         - configMapRef:

--- a/kubernetes/apps/leantime/production.yaml
+++ b/kubernetes/apps/leantime/production.yaml
@@ -159,7 +159,7 @@ spec:
           done
       containers:
       - name: leantime
-        image: leantime/leantime:3.7.3
+        image: leantime/leantime:3.8.0
         imagePullPolicy: IfNotPresent
         envFrom:
         - configMapRef:


### PR DESCRIPTION
## Summary

Upgrades Leantime from `3.7.3` to `3.8.0` in both production and standalone demo manifests.

## Validation

- Ran `scripts/test-iac-static.sh`
- Ran `scripts/dev-leantime-smoke.sh`
- Local k3d rollout completed successfully
- Leantime responded at `/auth/login` and redirected to install on a fresh dev DB

## Notes

This is intentionally a narrow image-tag upgrade. It does not change database config, PVCs, ingress, plugins, or secrets.

## Production rollout checklist

Before merge/deploy:

- Take a Leantime DB backup.
- Confirm current app health in Argo/k3s.
- Merge PR.
- Push/pull updated main to the framework desktop repo path used by Argo.
- Sync `platform-leantime`.
- Watch rollout and logs.
- Test login, dashboard, project pages, plugins, email, and the prior bad-import scenario.

## Rollback

Revert the image tag to `leantime/leantime:3.7.3` and resync `platform-leantime`.

If 3.8 performs database migrations that prevent rollback, restore from the pre-upgrade DB backup.