### PR TITLE
Surface Leantime app logs in Loki

### DIFF
--- a/ansible/roles/platform_validation/tasks/main.yml
+++ b/ansible/roles/platform_validation/tasks/main.yml
@@ -240,6 +240,29 @@
     gitops_revision not in loki_application_sources.stdout
   when: monitoring_enabled | default(true) | bool
 
+- name: Verify Leantime app log sidecar is reconciled
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - deployment
+      - leantime
+      - -n
+      - default
+      - -o
+      - "jsonpath={range .spec.template.spec.containers[*]}container={.name}{'\\n'}{end}{range .spec.template.spec.initContainers[*]}initContainer={.name}{'\\n'}{end}{range .spec.template.spec.volumes[*]}volume={.name}{'\\n'}{end}"
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: leantime_log_sidecar
+  changed_when: false
+  failed_when: >
+    leantime_log_sidecar.rc != 0 or
+    'container=leantime-app-log-tail' not in leantime_log_sidecar.stdout or
+    'initContainer=prepare-leantime-log-dir' not in leantime_log_sidecar.stdout or
+    'volume=leantime-app-logs' not in leantime_log_sidecar.stdout
+  when: monitoring_enabled | default(true) | bool
+
 - name: Verify Leantime logs dashboard is reconciled
   ansible.builtin.command:
     argv:
@@ -257,6 +280,25 @@
   register: leantime_logs_dashboard
   changed_when: false
   failed_when: leantime_logs_dashboard.rc != 0 or leantime_logs_dashboard.stdout | default('') | trim != '1'
+  when: monitoring_enabled | default(true) | bool
+
+- name: Verify Leantime logs dashboard queries app log sidecar
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - configmap
+      - leantime-logs-dashboard
+      - -n
+      - monitoring
+      - -o
+      - yaml
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: leantime_logs_dashboard_body
+  changed_when: false
+  failed_when: leantime_logs_dashboard_body.rc != 0 or not (leantime_logs_dashboard_body.stdout is search('leantime-app-log-tail'))
   when: monitoring_enabled | default(true) | bool
 
 - name: Verify Baserow logs dashboard is reconciled

--- a/kubernetes/apps/leantime/demo-standalone.yaml
+++ b/kubernetes/apps/leantime/demo-standalone.yaml
@@ -195,6 +195,22 @@ spec:
         app: leantime
     spec:
       initContainers:
+      - name: prepare-leantime-log-dir
+        image: leantime/leantime:3.8.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        command:
+        - sh
+        - -ceu
+        - |
+          mkdir -p /var/www/html/storage/logs
+          chown -R 1000:1000 /var/www/html/storage/logs
+          chmod 0775 /var/www/html/storage/logs
+        volumeMounts:
+        - name: leantime-app-logs
+          mountPath: /var/www/html/storage/logs
       - name: wait-for-mariadb
         image: mariadb:11.8.6-ubi9
         imagePullPolicy: IfNotPresent
@@ -265,6 +281,44 @@ spec:
           mountPath: /var/www/html/user/data
         - name: leantime-plugins
           mountPath: /var/www/html/app/Plugins
+        - name: leantime-app-logs
+          mountPath: /var/www/html/storage/logs
+      - name: leantime-app-log-tail
+        image: leantime/leantime:3.8.0
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -ceu
+        - |
+          log_dir=/var/www/html/storage/logs
+          mkdir -p "${log_dir}"
+          touch "${log_dir}/leantime.log" "${log_dir}/deprecations.log"
+          echo "Tailing Leantime application log files from ${log_dir}"
+          while true; do
+            current_day="$(date +%F)"
+            daily_log="${log_dir}/leantime-${current_day}.log"
+            touch "${daily_log}"
+            tail -n +1 -F \
+              "${log_dir}/leantime.log" \
+              "${log_dir}/deprecations.log" \
+              "${daily_log}" &
+            tail_pid="$!"
+            while [ "$(date +%F)" = "${current_day}" ]; do
+              sleep 300
+            done
+            kill "${tail_pid}" >/dev/null 2>&1 || true
+            wait "${tail_pid}" >/dev/null 2>&1 || true
+          done
+        volumeMounts:
+        - name: leantime-app-logs
+          mountPath: /var/www/html/storage/logs
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "32Mi"
+          limits:
+            cpu: "100m"
+            memory: "128Mi"
       volumes:
       - name: leantime-vol
         persistentVolumeClaim:
@@ -272,6 +326,8 @@ spec:
       - name: leantime-plugins
         persistentVolumeClaim:
           claimName: leantime-plugins-data
+      - name: leantime-app-logs
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/apps/leantime/production.yaml
+++ b/kubernetes/apps/leantime/production.yaml
@@ -138,6 +138,22 @@ spec:
         app: leantime
     spec:
       initContainers:
+      - name: prepare-leantime-log-dir
+        image: leantime/leantime:3.8.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        command:
+        - sh
+        - -ceu
+        - |
+          mkdir -p /var/www/html/storage/logs
+          chown -R 1000:1000 /var/www/html/storage/logs
+          chmod 0775 /var/www/html/storage/logs
+        volumeMounts:
+        - name: leantime-app-logs
+          mountPath: /var/www/html/storage/logs
       - name: wait-for-mariadb
         image: mariadb:11.8.6-ubi9
         imagePullPolicy: IfNotPresent
@@ -210,6 +226,8 @@ spec:
           mountPath: /var/www/html/user/data
         - name: leantime-plugins
           mountPath: /var/www/html/app/Plugins
+        - name: leantime-app-logs
+          mountPath: /var/www/html/storage/logs
         resources:
           requests:
             cpu: "100m"
@@ -217,6 +235,42 @@ spec:
           limits:
             cpu: "1000m"
             memory: "1Gi"
+      - name: leantime-app-log-tail
+        image: leantime/leantime:3.8.0
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -ceu
+        - |
+          log_dir=/var/www/html/storage/logs
+          mkdir -p "${log_dir}"
+          touch "${log_dir}/leantime.log" "${log_dir}/deprecations.log"
+          echo "Tailing Leantime application log files from ${log_dir}"
+          while true; do
+            current_day="$(date +%F)"
+            daily_log="${log_dir}/leantime-${current_day}.log"
+            touch "${daily_log}"
+            tail -n +1 -F \
+              "${log_dir}/leantime.log" \
+              "${log_dir}/deprecations.log" \
+              "${daily_log}" &
+            tail_pid="$!"
+            while [ "$(date +%F)" = "${current_day}" ]; do
+              sleep 300
+            done
+            kill "${tail_pid}" >/dev/null 2>&1 || true
+            wait "${tail_pid}" >/dev/null 2>&1 || true
+          done
+        volumeMounts:
+        - name: leantime-app-logs
+          mountPath: /var/www/html/storage/logs
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "32Mi"
+          limits:
+            cpu: "100m"
+            memory: "128Mi"
       volumes:
       - name: leantime-vol
         persistentVolumeClaim:
@@ -224,6 +278,8 @@ spec:
       - name: leantime-plugins
         persistentVolumeClaim:
           claimName: leantime-plugins-pvc
+      - name: leantime-app-logs
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/platform/monitoring/access/leantime-logs-dashboard.yaml
+++ b/kubernetes/platform/monitoring/access/leantime-logs-dashboard.yaml
@@ -70,7 +70,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Leantime Application Logs",
+          "title": "Leantime Container and Application Logs",
           "type": "logs"
         },
         {
@@ -107,7 +107,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Leantime Errors, Mail, and Invite Events",
+          "title": "Leantime Errors, App Exceptions, Mail, and Invite Events",
           "type": "logs"
         }
       ],
@@ -169,15 +169,15 @@ data:
           {
             "current": {
               "selected": false,
-              "text": "leantime",
-              "value": "leantime"
+              "text": "leantime|leantime-app-log-tail",
+              "value": "leantime|leantime-app-log-tail"
             },
             "hide": 0,
             "label": "Container Regex",
             "multi": false,
             "name": "container",
             "options": [],
-            "query": "leantime",
+            "query": "leantime|leantime-app-log-tail",
             "skipUrlSync": false,
             "type": "textbox"
           },
@@ -205,6 +205,6 @@ data:
       "timezone": "browser",
       "title": "Leantime Logs",
       "uid": "leantime-logs",
-      "version": 1,
+      "version": 2,
       "weekStart": ""
     }


### PR DESCRIPTION
## Summary

Surfaces Leantime file-based application logs through Kubernetes logs so Loki/Grafana can show real Leantime PHP/app errors.

Previously, Grafana could show container stdout/stderr, but Leantime stack traces were written to `/var/www/html/storage/logs/leantime-*.log` inside the container. That meant dashboard 500s were visible as access-log lines, but the useful `production.ERROR` stack traces required manual `kubectl exec` inspection.

## Changes

- Adds a `leantime-app-log-tail` sidecar to Leantime production and demo manifests.
- Mounts a shared `emptyDir` at `/var/www/html/storage/logs`.
- Adds an init container to prepare the shared log directory for Leantime's `www-data` UID/GID.
- Tails:
  - `leantime.log`
  - `leantime-YYYY-MM-DD.log`
  - `deprecations.log`
- Updates the Leantime Grafana dashboard to query both:
  - `leantime`
  - `leantime-app-log-tail`
- Adds production validation checks for:
  - Leantime app-log sidecar
  - shared log volume
  - dashboard query including the sidecar

## Validation

- Ran `scripts/test-iac-static.sh`
- Ran `scripts/dev-leantime-smoke.sh`
- Verified local Leantime rollout succeeds with the sidecar
- Verified Leantime file-log stack traces appear via:
```bash
kubectl logs deploy/leantime -n default -c leantime-app-log-tail
```
- Verified a marker written to `/var/www/html/storage/logs/leantime-$(date +%F).log` appears in the sidecar logs

## Why

This would have shortened the recent Leantime dashboard 500 investigation. The actual error was in Leantime’s internal app log file, not the main container stdout/stderr stream Grafana was showing.
