### PR TITLE
Hotfix/platform project app destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ This assumes a fresh Ubuntu/Debian host and no existing infrastructure.
    - `auth.thekeepstudios.com`
    - `projects.thekeepstudios.com`
    - `mindmaps.thekeepstudios.com`
-   - `relationships.thekeepstudios.com`
+   - `baserow.thekeepstudios.com`
    - `grafana.thekeepstudios.com`
    - `prometheus.thekeepstudios.com`
    - `alerts.thekeepstudios.com`

--- a/ansible/dev_vars.yml.example
+++ b/ansible/dev_vars.yml.example
@@ -41,7 +41,7 @@ local_dev_wisemapping_probe_host: mindmaps.thekeepstudios.com
 local_dev_wisemapping_wait_timeout: 10m
 local_dev_leantime_probe_host: projects.thekeepstudios.com
 local_dev_leantime_wait_timeout: 10m
-local_dev_baserow_probe_host: relationships.thekeepstudios.com
+local_dev_baserow_probe_host: baserow.thekeepstudios.com
 local_dev_baserow_wait_timeout: 15m
 local_dev_twenty_probe_host: twenty.thekeepstudios.com
 local_dev_twenty_wait_timeout: 20m

--- a/ansible/production_vars.yml.example
+++ b/ansible/production_vars.yml.example
@@ -75,7 +75,7 @@ platform_secrets:
 #   - "http://auth.thekeepstudios.com"
 #   - "http://projects.thekeepstudios.com"
 #   - "http://mindmaps.thekeepstudios.com"
-#   - "http://relationships.thekeepstudios.com"
+#   - "http://baserow.thekeepstudios.com"
 #   - "http://grafana.thekeepstudios.com"
 #   - "http://prometheus.thekeepstudios.com"
 #   - "http://alerts.thekeepstudios.com"

--- a/ansible/roles/dev_workstation/tasks/main.yml
+++ b/ansible/roles/dev_workstation/tasks/main.yml
@@ -175,7 +175,7 @@
     WISEMAPPING_WAIT_TIMEOUT: "{{ local_dev_wisemapping_wait_timeout | default('10m') }}"
     LEANTIME_PROBE_HOST: "{{ local_dev_leantime_probe_host | default('projects.thekeepstudios.com') }}"
     LEANTIME_WAIT_TIMEOUT: "{{ local_dev_leantime_wait_timeout | default('10m') }}"
-    BASEROW_PROBE_HOST: "{{ local_dev_baserow_probe_host | default('relationships.thekeepstudios.com') }}"
+    BASEROW_PROBE_HOST: "{{ local_dev_baserow_probe_host | default('baserow.thekeepstudios.com') }}"
     BASEROW_WAIT_TIMEOUT: "{{ local_dev_baserow_wait_timeout | default('15m') }}"
     TWENTY_PROBE_HOST: "{{ local_dev_twenty_probe_host | default('twenty.thekeepstudios.com') }}"
     TWENTY_WAIT_TIMEOUT: "{{ local_dev_twenty_wait_timeout | default('20m') }}"

--- a/ansible/roles/platform_validation/tasks/main.yml
+++ b/ansible/roles/platform_validation/tasks/main.yml
@@ -414,7 +414,7 @@
       - -ceu
       - |
         curl -fsS --max-time 20 \
-          -H "Host: relationships.thekeepstudios.com" \
+          -H "Host: baserow.thekeepstudios.com" \
           -H "X-Forwarded-Proto: https" \
           http://baserow/ > /tmp/baserow.html
         grep -Eiq "baserow|login|sign" /tmp/baserow.html
@@ -680,7 +680,7 @@
     url: "{{ item }}"
     status_code: [200, 401, 403]
     timeout: 15
-  loop: "{{ ['https://auth.thekeepstudios.com', 'https://projects.thekeepstudios.com', 'https://mindmaps.thekeepstudios.com', 'https://relationships.thekeepstudios.com', 'https://grafana.thekeepstudios.com', 'https://prometheus.thekeepstudios.com', 'https://alerts.thekeepstudios.com', 'https://argocd.thekeepstudios.com'] + (['https://twenty.thekeepstudios.com'] if (platform_validation_twenty_enabled | bool) else []) + (['https://espocrm.thekeepstudios.com'] if (platform_validation_espocrm_enabled | bool) else []) }}"
+  loop: "{{ ['https://auth.thekeepstudios.com', 'https://projects.thekeepstudios.com', 'https://mindmaps.thekeepstudios.com', 'https://baserow.thekeepstudios.com', 'https://grafana.thekeepstudios.com', 'https://prometheus.thekeepstudios.com', 'https://alerts.thekeepstudios.com', 'https://argocd.thekeepstudios.com'] + (['https://twenty.thekeepstudios.com'] if (platform_validation_twenty_enabled | bool) else []) + (['https://espocrm.thekeepstudios.com'] if (platform_validation_espocrm_enabled | bool) else []) }}"
   when: require_external_https | default(true) | bool
 
 - name: Verify protected endpoints require authentication

--- a/docs/local-iac-testing.md
+++ b/docs/local-iac-testing.md
@@ -195,7 +195,7 @@ local app is serving a real first-run page.
 Baserow probes `http://baserow/` with:
 
 ```text
-Host: relationships.thekeepstudios.com
+Host: baserow.thekeepstudios.com
 X-Forwarded-Proto: https
 ```
 

--- a/docs/relationship-os/implementation-plan.md
+++ b/docs/relationship-os/implementation-plan.md
@@ -26,7 +26,7 @@ Included:
 
 - Baserow all-in-one Kubernetes Deployment
 - PVC mounted at `/baserow/data`
-- Internal service and Traefik Ingress for `relationships.thekeepstudios.com`
+- Internal service and Traefik Ingress for `baserow.thekeepstudios.com`
 - Argo CD app registration as `platform-baserow`
 - Daily quiet-window backup CronJob
 - Restore runbook
@@ -48,11 +48,11 @@ Excluded:
 ## Rollout Checklist
 
 1. Create the Cloudflare Tunnel public hostname:
-   - Hostname: `relationships.thekeepstudios.com`
+   - Hostname: `baserow.thekeepstudios.com`
    - Service type: `HTTPS`
    - Service URL: `traefik.kube-system.svc.cluster.local`
    - Origin setting: `No TLS Verify`
-2. Add Cloudflare Access in front of `relationships.thekeepstudios.com`.
+2. Add Cloudflare Access in front of `baserow.thekeepstudios.com`.
 3. Apply or sync the `platform-baserow` Argo CD application.
 4. Wait for:
    - `application/platform-baserow` to become `Synced Healthy`

--- a/docs/relationship-os/restore-runbook.md
+++ b/docs/relationship-os/restore-runbook.md
@@ -127,7 +127,7 @@ kubectl rollout status deployment/baserow -n baserow --timeout=10m
 ```bash
 kubectl run -n baserow baserow-curl --rm -i --restart=Never \
   --image=curlimages/curl:8.8.0 -- \
-  sh -ceu 'curl -fsS -H "Host: relationships.thekeepstudios.com" -H "X-Forwarded-Proto: https" http://baserow/ | head'
+  sh -ceu 'curl -fsS -H "Host: baserow.thekeepstudios.com" -H "X-Forwarded-Proto: https" http://baserow/ | head'
 ```
 
 ## Gaps

--- a/kubernetes/apps/baserow/production.yaml
+++ b/kubernetes/apps/baserow/production.yaml
@@ -38,7 +38,7 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
         - name: BASEROW_PUBLIC_URL
-          value: https://relationships.thekeepstudios.com
+          value: https://baserow.thekeepstudios.com
         - name: BASEROW_RUN_MINIMAL
           value: "yes"
         - name: BASEROW_AMOUNT_OF_WORKERS
@@ -56,7 +56,7 @@ spec:
             port: http
             httpHeaders:
             - name: Host
-              value: relationships.thekeepstudios.com
+              value: baserow.thekeepstudios.com
             - name: X-Forwarded-Proto
               value: https
           failureThreshold: 60
@@ -68,7 +68,7 @@ spec:
             port: http
             httpHeaders:
             - name: Host
-              value: relationships.thekeepstudios.com
+              value: baserow.thekeepstudios.com
             - name: X-Forwarded-Proto
               value: https
           periodSeconds: 15
@@ -80,7 +80,7 @@ spec:
             port: http
             httpHeaders:
             - name: Host
-              value: relationships.thekeepstudios.com
+              value: baserow.thekeepstudios.com
             - name: X-Forwarded-Proto
               value: https
           periodSeconds: 30
@@ -125,7 +125,7 @@ metadata:
     traefik.ingress.kubernetes.io/service.serversscheme: http
 spec:
   rules:
-  - host: relationships.thekeepstudios.com
+  - host: baserow.thekeepstudios.com
     http:
       paths:
       - path: /

--- a/kubernetes/gitops/root/platform-project.yaml
+++ b/kubernetes/gitops/root/platform-project.yaml
@@ -21,6 +21,12 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: wisemapping
     server: https://kubernetes.default.svc
+  - namespace: baserow
+    server: https://kubernetes.default.svc
+  - namespace: twenty
+    server: https://kubernetes.default.svc
+  - namespace: espocrm
+    server: https://kubernetes.default.svc
   - namespace: monitoring
     server: https://kubernetes.default.svc
   - namespace: kube-system

--- a/kubernetes/gitops/templates/platform-project.yaml
+++ b/kubernetes/gitops/templates/platform-project.yaml
@@ -21,6 +21,12 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: wisemapping
     server: https://kubernetes.default.svc
+  - namespace: baserow
+    server: https://kubernetes.default.svc
+  - namespace: twenty
+    server: https://kubernetes.default.svc
+  - namespace: espocrm
+    server: https://kubernetes.default.svc
   - namespace: monitoring
     server: https://kubernetes.default.svc
   - namespace: kube-system

--- a/scripts/dev-observe.sh
+++ b/scripts/dev-observe.sh
@@ -86,7 +86,7 @@ app_config() {
       APP_SERVICE="baserow"
       APP_DEPLOYMENT="baserow"
       APP_PORT="${BASEROW_OBSERVE_PORT:-18082}"
-      APP_HOST="${BASEROW_PROBE_HOST:-relationships.thekeepstudios.com}"
+      APP_HOST="${BASEROW_PROBE_HOST:-baserow.thekeepstudios.com}"
       APP_PROBE_PATH="/"
       APP_PROBE_PATTERN="login|sign|create account"
       APP_CONFIG_KIND="baserow"

--- a/scripts/dev-smoke.sh
+++ b/scripts/dev-smoke.sh
@@ -177,7 +177,7 @@ smoke_leantime() {
 }
 
 smoke_baserow() {
-  local probe_host="${BASEROW_PROBE_HOST:-relationships.thekeepstudios.com}"
+  local probe_host="${BASEROW_PROBE_HOST:-baserow.thekeepstudios.com}"
   local wait_timeout="${BASEROW_WAIT_TIMEOUT:-${DEFAULT_WAIT_TIMEOUT}}"
   local probe_name
   local probe_output

--- a/scripts/production.env.example
+++ b/scripts/production.env.example
@@ -8,7 +8,7 @@ AUTHENTIK_URL=https://auth.thekeepstudios.com
 LEANTIME_URL=https://projects.thekeepstudios.com
 # GITLAB_URL=https://gitlab.thekeepstudios.com
 WISEMAPPING_URL=https://mindmaps.thekeepstudios.com
-BASEROW_URL=https://relationships.thekeepstudios.com
+BASEROW_URL=https://baserow.thekeepstudios.com
 
 # -----------------------------------------------------------------------------
 # Monitoring domains

--- a/scripts/validate-production-gate.sh
+++ b/scripts/validate-production-gate.sh
@@ -21,7 +21,7 @@ HTTPS_ENDPOINTS=(
   https://auth.thekeepstudios.com
   https://projects.thekeepstudios.com
   https://mindmaps.thekeepstudios.com
-  https://relationships.thekeepstudios.com
+  https://baserow.thekeepstudios.com
   https://grafana.thekeepstudios.com
   https://prometheus.thekeepstudios.com
   https://alerts.thekeepstudios.com


### PR DESCRIPTION
## Summary

- Allow the platform Argo project to deploy CRM namespaces: `baserow`, `twenty`, and `espocrm`.
- Update Baserow’s production hostname from `relationships.thekeepstudios.com` to `baserow.thekeepstudios.com`.
- Align validation, local smoke defaults, production env example, and runbooks with the new Baserow hostname.

## Validation

- `scripts/test-iac-static.sh`
- Production spot check already showed:
  - `https://baserow.thekeepstudios.com/` -> `302 /login`
  - `https://espocrm.thekeepstudios.com/` -> `200`