### PR TITLE
Prepare Authentik forward auth for platform apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ kubectl annotate application platform-root -n argocd \
 ### OIDC Notes
 
 Authentik is the intended internal identity hub. Configure Google once in Authentik upstream.
+For the platform-wide forward-auth path, see `docs/authentik-sso.md`.
 
 Callback URLs:
 

--- a/ansible/roles/platform_validation/tasks/main.yml
+++ b/ansible/roles/platform_validation/tasks/main.yml
@@ -136,6 +136,42 @@
   changed_when: false
   failed_when: cf_deploy.rc != 0 or (cf_deploy.stdout | default('0') | trim | int) == 0
 
+- name: Check Authentik forward-auth middleware
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - middleware
+      - authentik-forward-auth
+      - -n
+      - identity
+      - -o
+      - "jsonpath={.metadata.name}"
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: authentik_forward_auth_middleware
+  changed_when: false
+  failed_when: authentik_forward_auth_middleware.rc != 0 or authentik_forward_auth_middleware.stdout | default('') | trim != 'authentik-forward-auth'
+
+- name: Check Authentik forward-auth outpost routes
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - ingress
+      - authentik-forward-auth-outpost-routes
+      - -n
+      - identity
+      - -o
+      - "jsonpath={.metadata.name}"
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: authentik_forward_auth_outpost_routes
+  changed_when: false
+  failed_when: authentik_forward_auth_outpost_routes.rc != 0 or authentik_forward_auth_outpost_routes.stdout | default('') | trim != 'authentik-forward-auth-outpost-routes'
+
 - name: Check Leantime backup CronJob
   ansible.builtin.command:
     argv:

--- a/docs/authentik-sso.md
+++ b/docs/authentik-sso.md
@@ -1,0 +1,95 @@
+# Authentik SSO Runbook
+
+Authentik is the platform identity hub. Use native OIDC for apps that support it
+well, and use Authentik Proxy Provider forward-auth for apps that need an
+external auth gate.
+
+## Current Pattern
+
+The Authentik deployment includes:
+
+- `identity/authentik-forward-auth`: Traefik `Middleware` for Authentik
+  forward-auth.
+- `identity/authentik-forward-auth-outpost-routes`: an Ingress that routes
+  `/outpost.goauthentik.io/*` on protected app hosts back to Authentik's
+  embedded outpost.
+
+The middleware is intentionally not attached to app ingresses by default. Attach
+it only after the Authentik Proxy Provider exists and the outpost route has been
+validated.
+
+## Authentik Setup
+
+In Authentik admin:
+
+1. Confirm `authentik Embedded Outpost` has `authentik_host` set to
+   `https://auth.thekeepstudios.com`.
+2. Create a Proxy Provider for platform forward-auth.
+3. Use Forward auth mode. Domain-level mode is the fastest internal-tools gate;
+   single-application mode gives better per-app access control.
+4. Create or attach an Authentik Application for the provider.
+5. Assign the provider to `authentik Embedded Outpost`.
+
+After saving, test an outpost route:
+
+```bash
+curl -I https://baserow.thekeepstudios.com/outpost.goauthentik.io/ping
+```
+
+A healthy route returns `204` or an Authentik-managed response, not a Traefik
+`404` and not the upstream application.
+
+## Enable Forward Auth
+
+Apply the middleware annotation to each app ingress once the provider is ready:
+
+```bash
+kubectl annotate ingress baserow-ingress -n baserow \
+  traefik.ingress.kubernetes.io/router.middlewares=identity-authentik-forward-auth@kubernetescrd \
+  --overwrite
+
+kubectl annotate ingress espocrm-ingress -n espocrm \
+  traefik.ingress.kubernetes.io/router.middlewares=identity-authentik-forward-auth@kubernetescrd \
+  --overwrite
+
+kubectl annotate ingress wisemapping-ingress -n wisemapping \
+  traefik.ingress.kubernetes.io/router.middlewares=identity-authentik-forward-auth@kubernetescrd \
+  --overwrite
+
+kubectl annotate ingress leantime-ingress -n default \
+  traefik.ingress.kubernetes.io/router.middlewares=identity-authentik-forward-auth@kubernetescrd \
+  --overwrite
+
+kubectl annotate ingress argocd-server-ingress -n argocd \
+  traefik.ingress.kubernetes.io/router.middlewares=identity-authentik-forward-auth@kubernetescrd \
+  --overwrite
+```
+
+For monitoring, replace the current BasicAuth middleware in
+`kubernetes/platform/monitoring/kube-prometheus-stack.values.yaml` with:
+
+```yaml
+traefik.ingress.kubernetes.io/router.middlewares: identity-authentik-forward-auth@kubernetescrd
+```
+
+If an ingress already has a middleware that must remain, chain both values with a
+comma in Traefik annotation order:
+
+```yaml
+traefik.ingress.kubernetes.io/router.middlewares: identity-authentik-forward-auth@kubernetescrd,namespace-other-middleware@kubernetescrd
+```
+
+## Native OIDC Follow-Up
+
+Native app SSO is preferable when the app handles authorization cleanly:
+
+- Leantime reads OIDC settings from `platform_oidc.leantime` and the
+  `leantime-oidc` secret.
+- WiseMapping has an `oidc` Spring profile but needs Authentik client values in
+  `platform_oidc.wisemapping`.
+- Argo CD, Grafana, and GitLab should move from proxy-only gates to native OIDC
+  once provider automation is in place.
+
+Keep Baserow and EspoCRM behind forward-auth unless a supported native OIDC
+configuration is deliberately added and tested.
+

--- a/kubernetes/platform/authentik/standalone.yaml
+++ b/kubernetes/platform/authentik/standalone.yaml
@@ -352,6 +352,29 @@ spec:
       X-Forwarded-Proto: "https"
       X-Forwarded-Ssl: "on"
 ---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: authentik-forward-auth
+  namespace: identity
+spec:
+  forwardAuth:
+    address: http://authentik.identity.svc.cluster.local/outpost.goauthentik.io/auth/traefik
+    trustForwardHeader: true
+    authResponseHeaders:
+    - X-authentik-username
+    - X-authentik-groups
+    - X-authentik-entitlements
+    - X-authentik-email
+    - X-authentik-name
+    - X-authentik-uid
+    - X-authentik-jwt
+    - X-authentik-meta-jwks
+    - X-authentik-meta-outpost
+    - X-authentik-meta-provider
+    - X-authentik-meta-app
+    - X-authentik-meta-version
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -366,6 +389,96 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: authentik
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: authentik-forward-auth-outpost-routes
+  namespace: identity
+  annotations:
+    traefik.ingress.kubernetes.io/service.serversscheme: http
+spec:
+  rules:
+  - host: projects.thekeepstudios.com
+    http:
+      paths:
+      - path: /outpost.goauthentik.io
+        pathType: Prefix
+        backend:
+          service:
+            name: authentik
+            port:
+              number: 80
+  - host: mindmaps.thekeepstudios.com
+    http:
+      paths:
+      - path: /outpost.goauthentik.io
+        pathType: Prefix
+        backend:
+          service:
+            name: authentik
+            port:
+              number: 80
+  - host: baserow.thekeepstudios.com
+    http:
+      paths:
+      - path: /outpost.goauthentik.io
+        pathType: Prefix
+        backend:
+          service:
+            name: authentik
+            port:
+              number: 80
+  - host: espocrm.thekeepstudios.com
+    http:
+      paths:
+      - path: /outpost.goauthentik.io
+        pathType: Prefix
+        backend:
+          service:
+            name: authentik
+            port:
+              number: 80
+  - host: grafana.thekeepstudios.com
+    http:
+      paths:
+      - path: /outpost.goauthentik.io
+        pathType: Prefix
+        backend:
+          service:
+            name: authentik
+            port:
+              number: 80
+  - host: prometheus.thekeepstudios.com
+    http:
+      paths:
+      - path: /outpost.goauthentik.io
+        pathType: Prefix
+        backend:
+          service:
+            name: authentik
+            port:
+              number: 80
+  - host: alerts.thekeepstudios.com
+    http:
+      paths:
+      - path: /outpost.goauthentik.io
+        pathType: Prefix
+        backend:
+          service:
+            name: authentik
+            port:
+              number: 80
+  - host: argocd.thekeepstudios.com
+    http:
+      paths:
+      - path: /outpost.goauthentik.io
         pathType: Prefix
         backend:
           service:

--- a/scripts/validate-production-gate.sh
+++ b/scripts/validate-production-gate.sh
@@ -92,6 +92,20 @@ check_cloudflare_tunnel() {
   fi
 }
 
+check_authentik_forward_auth() {
+  if kadmin get middleware authentik-forward-auth -n identity >/dev/null 2>&1; then
+    pass "Authentik forward-auth middleware exists"
+  else
+    fail "Authentik forward-auth middleware is missing"
+  fi
+
+  if kadmin get ingress authentik-forward-auth-outpost-routes -n identity >/dev/null 2>&1; then
+    pass "Authentik forward-auth outpost routes exist"
+  else
+    fail "Authentik forward-auth outpost routes are missing"
+  fi
+}
+
 check_backup_resources() {
   if kadmin get cronjob leantime-db-backup -n default >/dev/null 2>&1; then
     pass "Leantime backup CronJob exists"
@@ -179,6 +193,7 @@ check_direct_http_urls() {
 
 check_cluster
 check_cloudflare_tunnel
+check_authentik_forward_auth
 check_argocd_apps
 check_backup_resources
 check_https_endpoints


### PR DESCRIPTION
## Summary
- add an Authentik Traefik forward-auth middleware for platform app protection
- route `/outpost.goauthentik.io/*` on app hostnames back to the embedded Authentik outpost
- document the SSO enablement runbook and wire validation checks into the Ansible role and legacy production gate

## Notes
- This intentionally does not attach the middleware to app ingresses yet. We should configure and verify the Authentik Proxy Provider/outpost first, then enable per ingress.
- Native OIDC remains the follow-up path for apps that support it cleanly.

## Validation
- `scripts/test-iac-static.sh`