### PR TITLE
Make EspoCRM email server allowlist configurable

### DIFF
--- a/ansible/production_vars.yml.example
+++ b/ansible/production_vars.yml.example
@@ -34,6 +34,11 @@ platform_secrets:
 #     enabled: false
 #   espocrm:
 #     enabled: false
+#     # Optional. Exact host:port entries only; wildcards are rejected.
+#     # Omit this key to leave the EspoCRM setting unmanaged.
+#     email_server_allowed_address_list:
+#       - "imap.example.com:993"
+#       - "smtp.example.com:587"
 
 # Optional: enable these only when gitops_repo_private is true.
 # gitops_repo_ssh_private_key_path: "/path/to/argocd-readonly-key"

--- a/ansible/roles/platform_gitops/tasks/main.yml
+++ b/ansible/roles/platform_gitops/tasks/main.yml
@@ -635,6 +635,169 @@
   delay: 10
   changed_when: false
 
+- name: Define EspoCRM email server allowlist configuration
+  ansible.builtin.set_fact:
+    espocrm_email_server_allowed_address_list: >-
+      {{ ((platform_optional_apps | default({})).espocrm | default({})).get('email_server_allowed_address_list', []) }}
+    espocrm_email_server_allowed_address_list_hash: >-
+      {{ ((platform_optional_apps | default({})).espocrm | default({})).get('email_server_allowed_address_list', []) | to_json | hash('sha256') }}
+  when:
+    - ((platform_optional_apps | default({})).espocrm | default({})).enabled | default(false) | bool
+    - ((platform_optional_apps | default({})).espocrm | default({})).email_server_allowed_address_list is defined
+
+- name: Read applied EspoCRM email server allowlist configuration hash
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - configmap
+      - espocrm-runtime-config-state
+      - -n
+      - espocrm
+      - -o
+      - "jsonpath={.data.emailServerAllowedAddressListHash}"
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: espocrm_runtime_config_state
+  changed_when: false
+  failed_when: false
+  when: espocrm_email_server_allowed_address_list is defined
+
+- name: Apply EspoCRM runtime configuration
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - apply
+      - -f
+      - "-"
+  args:
+    stdin: >-
+      {{
+        {
+          'apiVersion': 'v1',
+          'kind': 'ConfigMap',
+          'metadata': {
+            'name': 'espocrm-runtime-config',
+            'namespace': 'espocrm'
+          },
+          'data': {
+            'email-server-allowed-address-list.json': espocrm_email_server_allowed_address_list | to_json
+          }
+        } | to_nice_yaml
+      }}
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: espocrm_runtime_config_apply
+  changed_when: >
+    'created' in espocrm_runtime_config_apply.stdout or
+    'configured' in espocrm_runtime_config_apply.stdout
+  when: espocrm_email_server_allowed_address_list is defined
+
+- name: Determine whether EspoCRM runtime configuration requires a restart
+  ansible.builtin.set_fact:
+    espocrm_runtime_config_restart_required: >-
+      {{
+        (espocrm_runtime_config_apply.changed | default(false)) or
+        (
+          espocrm_runtime_config_state.stdout | default('') | trim !=
+          espocrm_email_server_allowed_address_list_hash
+        )
+      }}
+  when: espocrm_email_server_allowed_address_list is defined
+
+- name: Wait for EspoCRM deployments before applying runtime configuration
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - get
+      - deployment
+      - espocrm
+      - espocrm-daemon
+      - -n
+      - espocrm
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  register: espocrm_runtime_config_deployments
+  until: espocrm_runtime_config_deployments.rc == 0
+  retries: 60
+  delay: 5
+  changed_when: false
+  when:
+    - espocrm_email_server_allowed_address_list is defined
+    - espocrm_runtime_config_restart_required | bool
+
+- name: Restart EspoCRM pods after runtime configuration changes
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - delete
+      - pod
+      - -l
+      - app=espocrm
+      - -n
+      - espocrm
+      - --ignore-not-found=true
+      - --wait=false
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  when:
+    - espocrm_email_server_allowed_address_list is defined
+    - espocrm_runtime_config_restart_required | bool
+
+- name: Wait for EspoCRM after runtime configuration changes
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - rollout
+      - status
+      - "deployment/{{ item }}"
+      - -n
+      - espocrm
+      - --timeout=300s
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  loop:
+    - espocrm
+    - espocrm-daemon
+  changed_when: false
+  when:
+    - espocrm_email_server_allowed_address_list is defined
+    - espocrm_runtime_config_restart_required | bool
+
+- name: Persist EspoCRM runtime configuration hash
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - apply
+      - -f
+      - "-"
+  args:
+    stdin: >-
+      {{
+        {
+          'apiVersion': 'v1',
+          'kind': 'ConfigMap',
+          'metadata': {
+            'name': 'espocrm-runtime-config-state',
+            'namespace': 'espocrm'
+          },
+          'data': {
+            'emailServerAllowedAddressListHash': espocrm_email_server_allowed_address_list_hash
+          }
+        } | to_nice_yaml
+      }}
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  when:
+    - espocrm_email_server_allowed_address_list is defined
+    - espocrm_runtime_config_restart_required | bool
+
 - name: Define Leantime email configuration hash
   ansible.builtin.set_fact:
     leantime_email_config_hash: >-

--- a/ansible/setup_k3s_production.yml
+++ b/ansible/setup_k3s_production.yml
@@ -96,6 +96,43 @@
         platform_optional_espocrm_enabled: "{{ ((platform_optional_apps | default({})).espocrm | default({})).enabled | default(false) | bool }}"
       tags: [always]
 
+    - name: Fail if EspoCRM email server allowlist is not a list
+      ansible.builtin.fail:
+        msg: "platform_optional_apps.espocrm.email_server_allowed_address_list must be a YAML list of exact host:port strings."
+      when:
+        - ((platform_optional_apps | default({})).espocrm | default({})).email_server_allowed_address_list is defined
+        - ((platform_optional_apps | default({})).espocrm | default({})).email_server_allowed_address_list | type_debug != "list"
+      tags: [always]
+
+    - name: Fail if EspoCRM email server allowlist contains invalid entries
+      ansible.builtin.fail:
+        msg: "Invalid EspoCRM email server allowlist entry '{{ item }}'. Use exact host:port values only; wildcards are not allowed."
+      vars:
+        espocrm_email_server_address: "{{ item | string | trim }}"
+        espocrm_email_server_port: "{{ espocrm_email_server_address | regex_replace('^.*:', '') }}"
+      loop: "{{ ((platform_optional_apps | default({})).espocrm | default({})).email_server_allowed_address_list | default([]) }}"
+      when: >
+        (((platform_optional_apps | default({})).espocrm | default({})).email_server_allowed_address_list is defined) and
+        (
+          (item | type_debug != "str") or
+          (espocrm_email_server_address != item) or
+          ('*' in espocrm_email_server_address) or
+          (not (espocrm_email_server_address is match('^(?:\\[[0-9A-Fa-f:.]+\\]|[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?):[0-9]{1,5}$'))) or
+          ((espocrm_email_server_port | int) < 1) or
+          ((espocrm_email_server_port | int) > 65535)
+        )
+      tags: [always]
+
+    - name: Fail if EspoCRM email server allowlist contains duplicates
+      ansible.builtin.fail:
+        msg: "platform_optional_apps.espocrm.email_server_allowed_address_list contains duplicate entries."
+      vars:
+        espocrm_email_server_allowed_address_list: "{{ ((platform_optional_apps | default({})).espocrm | default({})).email_server_allowed_address_list | default([]) }}"
+      when:
+        - ((platform_optional_apps | default({})).espocrm | default({})).email_server_allowed_address_list is defined
+        - espocrm_email_server_allowed_address_list | unique | length != espocrm_email_server_allowed_address_list | length
+      tags: [always]
+
     - name: Define required optional CRM secret keys
       ansible.builtin.set_fact:
         required_optional_crm_secret_keys: >-

--- a/docs/optional-crm-apps.md
+++ b/docs/optional-crm-apps.md
@@ -71,6 +71,23 @@ platform_optional_apps:
 
 Add only the secrets required by the enabled app.
 
+EspoCRM can optionally manage `emailServerAllowedAddressList` from
+`ansible/production_vars.yml`. Entries must be exact `host:port` pairs;
+wildcards are rejected.
+
+```yaml
+platform_optional_apps:
+  espocrm:
+    enabled: true
+    email_server_allowed_address_list:
+      - "imap.example.com:993"
+      - "smtp.example.com:587"
+```
+
+Omit `email_server_allowed_address_list` to leave the EspoCRM setting
+unmanaged. Set it to `[]` to explicitly clear an allowlist previously managed
+through this playbook.
+
 Twenty:
 
 ```yaml

--- a/kubernetes/apps/espocrm/production.yaml
+++ b/kubernetes/apps/espocrm/production.yaml
@@ -27,6 +27,79 @@ spec:
     requests:
       storage: 10Gi
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: espocrm-runtime-config-loader
+  namespace: espocrm
+data:
+  apply-runtime-config.php: |
+    <?php
+
+    $inputPath = '/config/email-server-allowed-address-list.json';
+    $targetPath = '/var/www/html/data/config-internal-override.php';
+    $targetDirectory = dirname($targetPath);
+
+    if (!is_file($inputPath)) {
+        exit(0);
+    }
+
+    if (!is_dir($targetDirectory) && !mkdir($targetDirectory, 0775, true) && !is_dir($targetDirectory)) {
+        throw new RuntimeException('Could not create the EspoCRM data directory.');
+    }
+
+    $list = json_decode(file_get_contents($inputPath), true, 512, JSON_THROW_ON_ERROR);
+
+    if (!is_array($list)) {
+        throw new RuntimeException('EspoCRM email server allowlist must be a JSON array.');
+    }
+
+    foreach ($list as $item) {
+        if (!is_string($item)) {
+            throw new RuntimeException('EspoCRM email server allowlist entries must be strings.');
+        }
+    }
+
+    $config = [];
+
+    if (is_file($targetPath)) {
+        $loadedConfig = include $targetPath;
+
+        if (!is_array($loadedConfig)) {
+            throw new RuntimeException('Existing EspoCRM internal override config must return an array.');
+        }
+
+        $config = $loadedConfig;
+    }
+
+    $config['emailServerAllowedAddressList'] = array_values($list);
+
+    $tmpPath = tempnam($targetDirectory, '.config-internal-override.');
+
+    if ($tmpPath === false) {
+        throw new RuntimeException('Could not create a temporary EspoCRM config file.');
+    }
+
+    $contents = "<?php\n\nreturn " . var_export($config, true) . ";\n";
+
+    try {
+        if (file_put_contents($tmpPath, $contents, LOCK_EX) === false) {
+            throw new RuntimeException('Could not write the EspoCRM config override.');
+        }
+
+        if (!rename($tmpPath, $targetPath)) {
+            throw new RuntimeException('Could not replace the EspoCRM config override.');
+        }
+
+        if (!chmod($targetPath, 0644)) {
+            throw new RuntimeException('Could not set permissions on the EspoCRM config override.');
+        }
+    } finally {
+        if (is_file($tmpPath)) {
+            unlink($tmpPath);
+        }
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -132,6 +205,22 @@ spec:
         app: espocrm
         component: web
     spec:
+      initContainers:
+      - name: espocrm-runtime-config
+        image: espocrm/espocrm:9.3.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - php
+        - /runtime-config-loader/apply-runtime-config.php
+        volumeMounts:
+        - name: data
+          mountPath: /var/www/html
+        - name: runtime-config
+          mountPath: /config
+          readOnly: true
+        - name: runtime-config-loader
+          mountPath: /runtime-config-loader
+          readOnly: true
       containers:
       - name: espocrm
         image: espocrm/espocrm:9.3.8
@@ -197,6 +286,13 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: espocrm-data
+      - name: runtime-config
+        configMap:
+          name: espocrm-runtime-config
+          optional: true
+      - name: runtime-config-loader
+        configMap:
+          name: espocrm-runtime-config-loader
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -217,6 +313,22 @@ spec:
         app: espocrm
         component: daemon
     spec:
+      initContainers:
+      - name: espocrm-runtime-config
+        image: espocrm/espocrm:9.3.8
+        imagePullPolicy: IfNotPresent
+        command:
+        - php
+        - /runtime-config-loader/apply-runtime-config.php
+        volumeMounts:
+        - name: data
+          mountPath: /var/www/html
+        - name: runtime-config
+          mountPath: /config
+          readOnly: true
+        - name: runtime-config-loader
+          mountPath: /runtime-config-loader
+          readOnly: true
       containers:
       - name: espocrm-daemon
         image: espocrm/espocrm:9.3.8
@@ -237,6 +349,13 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: espocrm-data
+      - name: runtime-config
+        configMap:
+          name: espocrm-runtime-config
+          optional: true
+      - name: runtime-config-loader
+        configMap:
+          name: espocrm-runtime-config-loader
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

- add an optional IaC-managed `emailServerAllowedAddressList` path for EspoCRM
- keep public defaults provider-neutral; omitting the variable leaves the setting unmanaged
- validate exact `host:port` entries and reject wildcards, malformed ports, and duplicates
- restart EspoCRM web and daemon pods only when runtime configuration changes
- support an explicit empty list to clear a previously managed allowlist

## Validation

- `scripts/test-iac-static.sh`
- Ansible production playbook syntax check
- EspoCRM Kustomize render
- local k3d neutral/default behavior: effective allowlist was unset
- local k3d configured behavior: EspoCRM read the exact three test entries as `www-data`
- local k3d clear behavior: effective allowlist became `[]`
- wildcard validation: `*.gmail.com:993` was rejected
- generated `config-internal-override.php` passed PHP syntax validation

## Production rollout

Production was not changed by this PR preparation because k3s access on the host requires interactive sudo. After merge, configure the desired exact endpoints in ignored `ansible/production_vars.yml`, run the production playbook, and retest the EspoCRM personal-email IMAP connection.

External endpoint reachability was not validated from local k3d because that cluster currently has external DNS resolution failures.