### PR TITLE
Fix EspoCRM email allowlist verification

### DIFF
--- a/ansible/roles/espocrm_email_config/tasks/main.yml
+++ b/ansible/roles/espocrm_email_config/tasks/main.yml
@@ -227,8 +227,8 @@
   changed_when: false
   failed_when: >
     espocrm_email_config_effective_allowlist.rc != 0 or
-    (espocrm_email_config_effective_allowlist.stdout | trim) !=
-    (espocrm_email_server_allowed_address_list | to_json)
+    (espocrm_email_config_effective_allowlist.stdout | trim | from_json) !=
+    espocrm_email_server_allowed_address_list
   when:
     - espocrm_email_config_should_apply | bool
     - espocrm_email_config_verify_effective | bool


### PR DESCRIPTION
## Summary

- parse EspoCRM's effective allowlist JSON before comparison
- compare the resulting list semantically instead of comparing JSON formatting

## Why

The production rollout applied the exact intended allowlist successfully, but verification reported a false failure because Ansible's `to_json` inserted spaces while PHP's `json_encode` did not.

Observed effective value:

```json
["imap.gmail.com:993","smtp.gmail.com:587","smtp.gmail.com:465"]
```

## Validation

- `scripts/test-iac-static.sh`
- external EspoCRM health remained HTTP 200 after rollout