### PR TITLE
Define the public planning model and roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,97 +1,51 @@
 # Contributing
 
-The Keep Platform is both an operating platform and a public engineering
-project. Contributions should make the intent, risk, and operational impact of
-a change understandable without exposing private internal data.
+Keep changes focused, reviewable, and free of confidential data.
 
 ## Where Work Belongs
 
-Use public GitHub issues for:
+- **GitHub:** public roadmap, architecture, code, bugs, docs, and integrations.
+- **Leantime:** private execution, workload, and client-specific tasks.
+- **EspoCRM:** active job, sales, client, and publishing opportunities.
+- **Baserow:** relationship and organization memory.
+- **Gmail:** communication source, not a system of record.
 
-- bugs that can be described without secrets or private records;
-- architecture and implementation proposals;
-- installability, documentation, testing, and reliability work;
-- public roadmap and integration-boundary decisions;
-- upstream research and reproducible technical findings.
-
-Do not put the following in public GitHub issues, pull requests, logs, or
-fixtures:
-
-- credentials, tokens, private keys, cookies, kubeconfigs, or secret values;
-- client-specific implementation details or confidential commercial plans;
-- personal job-search, CRM, contact, rescue, adopter, foster, or medical data;
-- production database contents, exports, backups, or screenshots containing
-  private records;
-- undisclosed security vulnerabilities.
-
-Private execution planning and sensitive implementation details belong in
-Leantime. Active job, sales, client, and publishing opportunities belong in
-EspoCRM. Relationship and organization memory belongs in Baserow. Gmail is a
-communication source, not the canonical project tracker.
-
-Report vulnerabilities according to [`SECURITY.md`](SECURITY.md), not in a
-public issue.
+Never publish credentials, private CRM/contact/job-search data, client details,
+database exports, or undisclosed vulnerabilities. Follow `SECURITY.md`.
 
 ## Issue Titles
 
-Use a stable category prefix so the backlog remains scannable before a larger
-label taxonomy is justified:
+Use a stable prefix such as:
 
-| Prefix | Use |
-| --- | --- |
-| `Bug:` | Reproducible incorrect behavior |
-| `Security:` | Public hardening work without vulnerability details |
-| `Architecture:` | System boundaries and durable technical direction |
-| `Roadmap:` | Planning model, sequencing, and capability tracks |
-| `Installability:` | Bootstrap, local development, and onboarding |
-| `Demo Mode:` | Synthetic public demo experience and isolation |
-| `Integrations:` | Ownership and contracts between systems |
-| `AI Services:` | Shared AI platform capabilities |
-| `Meeting Intelligence:` | Transcript and meeting-memory workflows |
-| `Knowledge Memory:` | Searchable operating knowledge |
-| `AI Call Assistant:` | Call capture and transcription backends |
-| `Hardening:` | Post-prototype reliability and security controls |
-| `Spike:` | Time-bounded research with a decision deliverable |
-| `License:` | Licensing, trademark, and asset-policy decisions |
+`Bug:`, `Security:`, `Architecture:`, `Roadmap:`, `Installability:`,
+`Demo Mode:`, `Integrations:`, `AI Services:`, `Meeting Intelligence:`,
+`Knowledge Memory:`, `AI Call Assistant:`, `Hardening:`, `Spike:`, or
+`License:`.
 
-Add labels when they improve filtering, automation, or ownership. Do not create
-labels that merely duplicate the title prefix.
+Labels should add filtering or ownership value, not duplicate the title.
 
-## Writing An Issue
+## Good Issues
 
-A useful issue states:
+State:
 
-1. the user, business, or operational problem;
-2. the desired outcome;
-3. current evidence or reproduction steps;
-4. constraints and explicit non-goals;
-5. acceptance criteria that can be verified;
-6. security, privacy, data, deployment, and rollback concerns;
-7. related or blocking issues.
+1. the problem and desired outcome;
+2. evidence or reproduction;
+3. constraints and non-goals;
+4. verifiable acceptance criteria;
+5. security, data, deployment, and rollback concerns;
+6. dependencies.
 
-Research issues should end in a recommendation, rejected alternatives, and
-follow-up work. Broad architecture issues should be split before production
-implementation when their decisions are still unsettled.
+Research issues should end in a recommendation, not an implied implementation.
 
 ## Pull Requests
 
-- Use one focused branch and pull request per issue.
-- Start from an updated `main`.
-- Do not mix unrelated cleanup or local artifacts into the branch.
-- Include the issue reference, tests, assumptions, known gaps, operational
-  impact, and rollback considerations.
-- Keep infrastructure pull requests in draft until rendering, syntax, and
-  relevant local smoke checks have passed.
-- Do not merge and deploy as one unreviewed action. Production changes require
-  separate human approval and validation.
-- Identify AI-authored or substantially AI-assisted work in the pull request.
+- Use one issue, branch, and PR per concern.
+- Start from updated `main`.
+- Stage only intentional files.
+- Include tests, assumptions, gaps, operational impact, and rollback.
+- Keep infrastructure PRs draft until relevant static/smoke checks pass.
+- Merge and deploy as separate human-approved actions.
+- Identify substantially AI-authored work.
 
-Repository-wide engineering and autonomous-agent expectations are also defined
-in `.aiassistant/rules/`.
-
-## Roadmap
-
-The public planning model and current capability tracks are documented in
-[`docs/roadmap.md`](docs/roadmap.md). The roadmap provides direction and
-dependency context; individual GitHub issues remain the source for acceptance
-criteria and implementation evidence.
+See `docs/roadmap.md` for public planning and `.aiassistant/rules/` for
+repository working rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing
+
+The Keep Platform is both an operating platform and a public engineering
+project. Contributions should make the intent, risk, and operational impact of
+a change understandable without exposing private internal data.
+
+## Where Work Belongs
+
+Use public GitHub issues for:
+
+- bugs that can be described without secrets or private records;
+- architecture and implementation proposals;
+- installability, documentation, testing, and reliability work;
+- public roadmap and integration-boundary decisions;
+- upstream research and reproducible technical findings.
+
+Do not put the following in public GitHub issues, pull requests, logs, or
+fixtures:
+
+- credentials, tokens, private keys, cookies, kubeconfigs, or secret values;
+- client-specific implementation details or confidential commercial plans;
+- personal job-search, CRM, contact, rescue, adopter, foster, or medical data;
+- production database contents, exports, backups, or screenshots containing
+  private records;
+- undisclosed security vulnerabilities.
+
+Private execution planning and sensitive implementation details belong in
+Leantime. Active job, sales, client, and publishing opportunities belong in
+EspoCRM. Relationship and organization memory belongs in Baserow. Gmail is a
+communication source, not the canonical project tracker.
+
+Report vulnerabilities according to [`SECURITY.md`](SECURITY.md), not in a
+public issue.
+
+## Issue Titles
+
+Use a stable category prefix so the backlog remains scannable before a larger
+label taxonomy is justified:
+
+| Prefix | Use |
+| --- | --- |
+| `Bug:` | Reproducible incorrect behavior |
+| `Security:` | Public hardening work without vulnerability details |
+| `Architecture:` | System boundaries and durable technical direction |
+| `Roadmap:` | Planning model, sequencing, and capability tracks |
+| `Installability:` | Bootstrap, local development, and onboarding |
+| `Demo Mode:` | Synthetic public demo experience and isolation |
+| `Integrations:` | Ownership and contracts between systems |
+| `AI Services:` | Shared AI platform capabilities |
+| `Meeting Intelligence:` | Transcript and meeting-memory workflows |
+| `Knowledge Memory:` | Searchable operating knowledge |
+| `AI Call Assistant:` | Call capture and transcription backends |
+| `Hardening:` | Post-prototype reliability and security controls |
+| `Spike:` | Time-bounded research with a decision deliverable |
+| `License:` | Licensing, trademark, and asset-policy decisions |
+
+Add labels when they improve filtering, automation, or ownership. Do not create
+labels that merely duplicate the title prefix.
+
+## Writing An Issue
+
+A useful issue states:
+
+1. the user, business, or operational problem;
+2. the desired outcome;
+3. current evidence or reproduction steps;
+4. constraints and explicit non-goals;
+5. acceptance criteria that can be verified;
+6. security, privacy, data, deployment, and rollback concerns;
+7. related or blocking issues.
+
+Research issues should end in a recommendation, rejected alternatives, and
+follow-up work. Broad architecture issues should be split before production
+implementation when their decisions are still unsettled.
+
+## Pull Requests
+
+- Use one focused branch and pull request per issue.
+- Start from an updated `main`.
+- Do not mix unrelated cleanup or local artifacts into the branch.
+- Include the issue reference, tests, assumptions, known gaps, operational
+  impact, and rollback considerations.
+- Keep infrastructure pull requests in draft until rendering, syntax, and
+  relevant local smoke checks have passed.
+- Do not merge and deploy as one unreviewed action. Production changes require
+  separate human approval and validation.
+- Identify AI-authored or substantially AI-assisted work in the pull request.
+
+Repository-wide engineering and autonomous-agent expectations are also defined
+in `.aiassistant/rules/`.
+
+## Roadmap
+
+The public planning model and current capability tracks are documented in
+[`docs/roadmap.md`](docs/roadmap.md). The roadmap provides direction and
+dependency context; individual GitHub issues remain the source for acceptance
+criteria and implementation evidence.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,147 @@
+# Public Roadmap
+
+The Keep Platform is a self-hosted operating stack, a reusable engineering
+portfolio, and a foundation for internal and client-facing workflows. This
+roadmap explains how public planning is organized without turning confidential
+operations into public project data.
+
+## Planning Systems
+
+| System | Canonical responsibility | Public? |
+| --- | --- | --- |
+| GitHub | Source, public roadmap, architecture, implementation, bugs, installability, integrations | Yes |
+| Leantime | Private execution, timeboxes, workload, client-specific tasks, sensitive planning | No |
+| EspoCRM | Active job, sales, client, consulting, and publishing opportunities | No |
+| Baserow | Relationship and organization memory that is not an active opportunity | No |
+| Gmail | Communication source and evidence; not a canonical planning database | No |
+
+The same fact should not silently become editable in every system. Integration
+work must name the system of record, allowed readers, allowed writers, approval
+requirements, and deletion behavior.
+
+## Roadmap States
+
+- **Now:** bounded work that improves the current platform without requiring an
+  unresolved architecture or policy decision.
+- **Next:** important work with known dependencies or sequencing constraints.
+- **Research:** a spike or design task whose output is a decision, not an
+  implied production commitment.
+- **Later:** valuable work that should not increase current operational risk or
+  distract from prerequisite controls.
+- **Decision required:** work that needs explicit human product, legal,
+  privacy, security, or branding direction.
+
+These states are planning guidance, not delivery-date promises.
+
+## Now
+
+### Platform Clarity And Operability
+
+- #13 documents the architecture and current operating model.
+- #21 improves local bootstrap, prerequisites, troubleshooting, and clean
+  environment validation.
+- #26 isolates the Leantime UI root from its MCP endpoint. The implementation
+  has merged; the remaining issue administration should confirm all acceptance
+  evidence before closure.
+
+### Public Planning
+
+- #11 defines this planning model, public/private boundaries, and contribution
+  expectations.
+
+## Next
+
+### Security And Integration Boundaries
+
+- #18 defines canonical ownership and safe read/write boundaries across
+  Leantime, EspoCRM, Baserow, GitHub, and Gmail.
+- #20 defines the shared authentication, authorization, secrets, approval, and
+  audit baseline.
+- #22 defines an isolated synthetic demo dataset, reset model, and onboarding
+  walkthrough.
+
+These should be reviewed before enabling broad assistant write access or a
+public demo environment.
+
+### AI Platform Foundations
+
+- #15 defines the internal LLM gateway, provider interface, permission model,
+  audit events, and tool-call approval boundary.
+- #16 defines consent-first meeting ingestion and portable meeting records.
+- #17 defines permission-aware organizational memory and retrieval.
+- #23 hardens the AI layer after #15 produces a concrete architecture.
+
+Dependency direction:
+
+```text
+#18 integration ownership ─┐
+#20 security baseline ─────┼─> #15 AI gateway ─> #23 hardening
+                           ├─> #16 meeting intelligence
+                           └─> #17 knowledge memory
+
+#16 meeting intelligence ─────> #17 knowledge memory
+```
+
+## Research
+
+### Call Assistant Backends
+
+- #24 evaluates Vexa as a browser-independent meeting capture backend.
+- #25 evaluates Amurex as a deployable component or upstream contribution
+  target.
+
+Neither candidate should be installed on production or trusted with meetings
+until its licensing, consent model, retention, authentication, dependencies,
+resource needs, and update path are understood.
+
+### EspoCRM Assistant Boundary
+
+- #29 compares existing EspoCRM MCP servers and should recommend build, wrap,
+  fork, or upstream contribution.
+- #28 defines the larger constrained assistant-facing EspoCRM capability.
+
+#29 should inform #28 before a server implementation is selected. A broad
+third-party CRUD server must not be exposed directly merely because it speaks
+MCP.
+
+## Later
+
+- Highly available k3s control plane and replicated storage.
+- Off-cluster immutable backups and scheduled restore drills.
+- Encrypted/delegated secret management with SOPS or External Secrets.
+- Automated Authentik provider and application reconciliation.
+- Public demo hosting after synthetic-data isolation and reset controls exist.
+- External/client AI workflows after the gateway and hardening controls are
+  implemented and reviewed.
+
+## Decision Required
+
+### Licensing And Brand Policy
+
+#12 proposes `AGPL-3.0-only` for platform source and separate treatment for
+trademarks and brand assets. Adding a license changes the legal terms of the
+repository and requires explicit maintainer approval of:
+
+- code license and version;
+- documentation and example licensing;
+- treatment of screenshots and generated artifacts;
+- ownership and allowed use of names, logos, and other brand assets;
+- whether existing third-party or copied material can be relicensed.
+
+Drafting may proceed, but the final policy should not be represented as adopted
+until that decision is made.
+
+## Issue Lifecycle
+
+1. Use a category prefix from `CONTRIBUTING.md`.
+2. Define verifiable acceptance criteria and dependencies.
+3. Use one branch and pull request per issue.
+4. Keep pull requests in draft while decisions or tests are incomplete.
+5. Record validation evidence and unresolved operational risk.
+6. Merge only after human review.
+7. Deploy production changes separately with explicit approval.
+8. Close an issue only after its acceptance criteria are actually satisfied.
+
+Follow-up capability issues already exist as #12 through #29. Create additional
+issues only when a discovered task is independently actionable; avoid duplicate
+backlog entries for work already represented here.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,147 +1,58 @@
 # Public Roadmap
 
-The Keep Platform is a self-hosted operating stack, a reusable engineering
-portfolio, and a foundation for internal and client-facing workflows. This
-roadmap explains how public planning is organized without turning confidential
-operations into public project data.
-
-## Planning Systems
-
-| System | Canonical responsibility | Public? |
-| --- | --- | --- |
-| GitHub | Source, public roadmap, architecture, implementation, bugs, installability, integrations | Yes |
-| Leantime | Private execution, timeboxes, workload, client-specific tasks, sensitive planning | No |
-| EspoCRM | Active job, sales, client, consulting, and publishing opportunities | No |
-| Baserow | Relationship and organization memory that is not an active opportunity | No |
-| Gmail | Communication source and evidence; not a canonical planning database | No |
-
-The same fact should not silently become editable in every system. Integration
-work must name the system of record, allowed readers, allowed writers, approval
-requirements, and deletion behavior.
-
-## Roadmap States
-
-- **Now:** bounded work that improves the current platform without requiring an
-  unresolved architecture or policy decision.
-- **Next:** important work with known dependencies or sequencing constraints.
-- **Research:** a spike or design task whose output is a decision, not an
-  implied production commitment.
-- **Later:** valuable work that should not increase current operational risk or
-  distract from prerequisite controls.
-- **Decision required:** work that needs explicit human product, legal,
-  privacy, security, or branding direction.
-
-These states are planning guidance, not delivery-date promises.
+GitHub holds public engineering plans; private execution and operating data stay
+in Leantime, EspoCRM, Baserow, and Gmail as described in `CONTRIBUTING.md`.
 
 ## Now
 
-### Platform Clarity And Operability
-
-- #13 documents the architecture and current operating model.
-- #21 improves local bootstrap, prerequisites, troubleshooting, and clean
-  environment validation.
-- #26 isolates the Leantime UI root from its MCP endpoint. The implementation
-  has merged; the remaining issue administration should confirm all acceptance
-  evidence before closure.
-
-### Public Planning
-
-- #11 defines this planning model, public/private boundaries, and contribution
-  expectations.
+- #11 public planning model
+- #13 architecture documentation
+- #21 local installability
+- #26 Leantime UI/MCP routing verification
 
 ## Next
 
-### Security And Integration Boundaries
+- #18 integration ownership and write boundaries
+- #20 authentication, authorization, secrets, approval, and audit baseline
+- #22 isolated synthetic demo mode
 
-- #18 defines canonical ownership and safe read/write boundaries across
-  Leantime, EspoCRM, Baserow, GitHub, and Gmail.
-- #20 defines the shared authentication, authorization, secrets, approval, and
-  audit baseline.
-- #22 defines an isolated synthetic demo dataset, reset model, and onboarding
-  walkthrough.
-
-These should be reviewed before enabling broad assistant write access or a
-public demo environment.
-
-### AI Platform Foundations
-
-- #15 defines the internal LLM gateway, provider interface, permission model,
-  audit events, and tool-call approval boundary.
-- #16 defines consent-first meeting ingestion and portable meeting records.
-- #17 defines permission-aware organizational memory and retrieval.
-- #23 hardens the AI layer after #15 produces a concrete architecture.
-
-Dependency direction:
+AI work depends on those boundaries:
 
 ```text
-#18 integration ownership ─┐
-#20 security baseline ─────┼─> #15 AI gateway ─> #23 hardening
-                           ├─> #16 meeting intelligence
-                           └─> #17 knowledge memory
-
-#16 meeting intelligence ─────> #17 knowledge memory
+#18 + #20 -> #15 AI gateway -> #23 hardening
+          -> #16 meeting intelligence -> #17 knowledge memory
 ```
 
 ## Research
 
-### Call Assistant Backends
+- #24 Vexa meeting-capture evaluation
+- #25 Amurex deployment/contribution evaluation
+- #29 EspoCRM MCP comparison before #28 implementation
 
-- #24 evaluates Vexa as a browser-independent meeting capture backend.
-- #25 evaluates Amurex as a deployable component or upstream contribution
-  target.
-
-Neither candidate should be installed on production or trusted with meetings
-until its licensing, consent model, retention, authentication, dependencies,
-resource needs, and update path are understood.
-
-### EspoCRM Assistant Boundary
-
-- #29 compares existing EspoCRM MCP servers and should recommend build, wrap,
-  fork, or upstream contribution.
-- #28 defines the larger constrained assistant-facing EspoCRM capability.
-
-#29 should inform #28 before a server implementation is selected. A broad
-third-party CRUD server must not be exposed directly merely because it speaks
-MCP.
+Research does not authorize installation or production use.
 
 ## Later
 
-- Highly available k3s control plane and replicated storage.
-- Off-cluster immutable backups and scheduled restore drills.
-- Encrypted/delegated secret management with SOPS or External Secrets.
-- Automated Authentik provider and application reconciliation.
-- Public demo hosting after synthetic-data isolation and reset controls exist.
-- External/client AI workflows after the gateway and hardening controls are
-  implemented and reviewed.
+- highly available k3s and replicated storage;
+- off-cluster backups and restore drills;
+- encrypted/delegated secret management;
+- automated Authentik reconciliation;
+- external/client AI workflows after hardening;
+- public demo hosting after isolation and reset controls.
 
 ## Decision Required
 
-### Licensing And Brand Policy
+#12 changes repository licensing and brand policy. Drafts are useful, but
+adoption requires explicit maintainer approval.
 
-#12 proposes `AGPL-3.0-only` for platform source and separate treatment for
-trademarks and brand assets. Adding a license changes the legal terms of the
-repository and requires explicit maintainer approval of:
+## Lifecycle
 
-- code license and version;
-- documentation and example licensing;
-- treatment of screenshots and generated artifacts;
-- ownership and allowed use of names, logos, and other brand assets;
-- whether existing third-party or copied material can be relicensed.
+1. Define verifiable acceptance criteria and dependencies.
+2. Use one branch and PR per issue.
+3. Keep incomplete work draft.
+4. Merge only after human review.
+5. Deploy production changes separately.
+6. Close issues only after acceptance evidence exists.
 
-Drafting may proceed, but the final policy should not be represented as adopted
-until that decision is made.
-
-## Issue Lifecycle
-
-1. Use a category prefix from `CONTRIBUTING.md`.
-2. Define verifiable acceptance criteria and dependencies.
-3. Use one branch and pull request per issue.
-4. Keep pull requests in draft while decisions or tests are incomplete.
-5. Record validation evidence and unresolved operational risk.
-6. Merge only after human review.
-7. Deploy production changes separately with explicit approval.
-8. Close an issue only after its acceptance criteria are actually satisfied.
-
-Follow-up capability issues already exist as #12 through #29. Create additional
-issues only when a discovered task is independently actionable; avoid duplicate
-backlog entries for work already represented here.
+Issues #12 through #29 already represent the current capability tracks. Avoid
+creating duplicate backlog entries.


### PR DESCRIPTION
## Summary

Implements the public planning model requested by #11.

- adds `CONTRIBUTING.md` with public/private work boundaries, issue-title prefixes, issue quality expectations, and PR hygiene
- adds `docs/roadmap.md` with Now, Next, Research, Later, and Decision Required states
- defines canonical responsibilities for GitHub, Leantime, EspoCRM, Baserow, and Gmail
- records dependency direction across security, integrations, AI services, meeting intelligence, knowledge memory, hardening, and EspoCRM assistant work
- points to the existing follow-up issue set instead of creating duplicate issues
- explicitly excludes secrets, private CRM/job-search data, confidential records, and undisclosed vulnerabilities from public GitHub

## Validation

- `git diff --check`
- local Markdown link resolution check for `CONTRIBUTING.md` and `docs/roadmap.md`
- exact staged-file review confirmed only the two planning documents were committed

## Dependencies

Independent of PR #30. If both merge, they touch different files.

## Operational Impact

Documentation and contribution policy only. No production or external system changes.

## Rollback

Revert commit `0be6f1c`.

## AI Attribution

Prepared autonomously by Codex under `.aiassistant/rules/Autonomous Agent Safety.md`. Human review is required before merge.

Closes #11