### PR TITLE
Add a clear local setup preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ HA means high availability: the system can survive the loss of one machine, proc
 
 ## What To Do First
 
+For local review without creating a cluster:
+
+```bash
+scripts/check-local-prereqs.sh static
+ansible-playbook -i ansible/inventory.ini ansible/setup_dev_environment.yml \
+  -e local_dev_profile=static
+```
+
+For the disposable local k3d sandbox:
+
+```bash
+scripts/check-local-prereqs.sh sandbox
+ansible-playbook -i ansible/inventory.ini ansible/setup_dev_environment.yml
+```
+
+See [`docs/local-iac-testing.md`](docs/local-iac-testing.md) for profiles,
+observation, cleanup, and troubleshooting.
+
 For a new production-like deployment:
 
 1. Copy `ansible/inventory.production.ini.example` to `ansible/inventory.production.ini`.

--- a/docs/local-iac-testing.md
+++ b/docs/local-iac-testing.md
@@ -18,6 +18,16 @@ The local path has three layers:
   requires at least 80 GiB and 8% free on the repo filesystem.
 - Optional: `kubeconform` or `kubeval` for stricter rendered manifest validation.
 
+Check the intended path before running it:
+
+```bash
+scripts/check-local-prereqs.sh static
+scripts/check-local-prereqs.sh sandbox
+```
+
+`static` requires Git, Bash, kubectl, and Ansible. `sandbox` additionally
+requires a working Docker daemon and k3d. The checker is read-only.
+
 ## Static Checks
 
 Run:
@@ -94,6 +104,9 @@ cp ansible/dev_vars.yml.example ansible/dev_vars.yml
 ```
 
 `ansible/dev_vars.yml` is ignored by Git.
+
+This file documents supported environment overrides. Prefer it over adding
+another `.env` or Compose configuration path.
 
 ## Disposable k3s Cluster
 
@@ -330,6 +343,10 @@ DEV_OBSERVE_PATCH_CONFIG=false scripts/dev-observe.sh wisemapping
 
 This local path does not replace production validation.
 
+The k3d path is the current sandbox/demo setup for reviewers. It uses
+deterministic development-only secrets, but it is not the planned public demo
+experience and must not use production exports.
+
 It does not test:
 
 - Cloudflare Tunnel.
@@ -340,3 +357,12 @@ It does not test:
 - Production backup and restore gates.
 
 Use it to catch render errors, startup failures, and service-level smoke test failures before pushing a branch to Argo CD.
+
+Common failures:
+
+- missing command: install the named prerequisite and rerun the checker;
+- Docker unavailable: make `docker info` work without sudo;
+- disk/pressure failure: free space, then recreate the disposable cluster;
+- image pull/network failure: retry after registry/network recovery;
+- port conflict during observation: use the documented `*_OBSERVE_PORT`
+  override.

--- a/scripts/check-local-prereqs.sh
+++ b/scripts/check-local-prereqs.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR%/*}"
+MODE="${1:-sandbox}"
+
+usage() {
+  echo "Usage: $0 [static|sandbox]"
+}
+
+case "${MODE}" in
+  static)
+    required=(git bash kubectl ansible-playbook)
+    ;;
+  sandbox)
+    required=(git bash kubectl ansible-playbook docker k3d)
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+missing=()
+for command_name in "${required[@]}"; do
+  command -v "${command_name}" >/dev/null 2>&1 || missing+=("${command_name}")
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  printf 'Missing required commands: %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+
+if [ "${MODE}" = "sandbox" ] &&
+   [ "${LOCAL_PREREQ_SKIP_DOCKER_INFO:-false}" != "true" ] &&
+   ! docker info >/dev/null 2>&1; then
+  echo "Docker is installed but unavailable to this user." >&2
+  echo "Start Docker and verify that 'docker info' works without sudo." >&2
+  exit 1
+fi
+
+if [ "${LOCAL_PREREQ_SKIP_DISK:-false}" != "true" ]; then
+  # shellcheck source=scripts/dev-preflight.sh
+  source "${SCRIPT_DIR}/dev-preflight.sh"
+  dev_preflight_check_disk "${PROJECT_ROOT}"
+fi
+
+echo "Local ${MODE} prerequisites passed."
+if [ "${MODE}" = "static" ]; then
+  echo "Next: ansible-playbook -i ansible/inventory.ini ansible/setup_dev_environment.yml -e local_dev_profile=static"
+else
+  echo "Next: ansible-playbook -i ansible/inventory.ini ansible/setup_dev_environment.yml"
+fi

--- a/scripts/test-iac-static.sh
+++ b/scripts/test-iac-static.sh
@@ -38,6 +38,9 @@ while IFS= read -r script; do
   bash -n "${script}"
 done < <(find scripts -maxdepth 1 -type f -name "*.sh" | sort)
 
+log "Local prerequisite checker tests"
+scripts/test-local-prereqs.sh
+
 log "Kustomize render check"
 while IFS= read -r kustomization; do
   dir="$(dirname "${kustomization}")"

--- a/scripts/test-local-prereqs.sh
+++ b/scripts/test-local-prereqs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/local-prereqs-test.XXXXXX")"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+make_stub() {
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${tmp_dir}/$1"
+  chmod +x "${tmp_dir}/$1"
+}
+
+for name in git bash kubectl ansible-playbook docker k3d; do
+  make_stub "${name}"
+done
+
+PATH="${tmp_dir}" \
+LOCAL_PREREQ_SKIP_DISK=true \
+LOCAL_PREREQ_SKIP_DOCKER_INFO=true \
+  /bin/bash "${SCRIPT_DIR}/check-local-prereqs.sh" sandbox >/dev/null
+
+mv "${tmp_dir}/kubectl" "${tmp_dir}/kubectl.disabled"
+if PATH="${tmp_dir}" LOCAL_PREREQ_SKIP_DISK=true \
+   /bin/bash "${SCRIPT_DIR}/check-local-prereqs.sh" static >/dev/null 2>&1; then
+  echo "Missing kubectl was accepted unexpectedly" >&2
+  exit 1
+fi
+
+echo "Local prerequisite checker tests passed."


### PR DESCRIPTION
## Summary

Improves the existing Ansible/k3d setup path for #21 without adding a competing Compose stack.

- adds `scripts/check-local-prereqs.sh` with `static` and `sandbox` modes
- reports all missing commands together and checks Docker access/disk for sandbox work
- adds a deterministic test covering success and missing-command failure
- runs that test from the existing static IaC gate
- adds concise README quickstarts and focused troubleshooting to the existing local testing guide
- treats k3d as the current reviewer sandbox while clearly distinguishing it from future public demo mode

## Validation

- `bash -n` for changed scripts
- `scripts/test-local-prereqs.sh`
- `scripts/check-local-prereqs.sh static`
- `scripts/check-local-prereqs.sh sandbox`
- `scripts/test-iac-static.sh`
- clean `ubuntu:24.04` container produced the intended first-run error: `Missing required commands: git kubectl ansible-playbook`

## Design Choice

No Docker Compose or additional `.env` path was added. The repository already has one supported Ansible/k3d workflow; duplicating it would increase drift and maintenance.

## Operational Impact

Local tooling and documentation only. The checker is read-only. No cluster or production changes are performed by it.

## Rollback

Revert commit `d09f4ee`.

## AI Attribution

Prepared autonomously by Codex under `.aiassistant/rules/Autonomous Agent Safety.md`. Human review is required before merge.

Relates to #21