### PR TITLE
Add a synthetic demo scenario contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Future target:
 
 HA means high availability: the system can survive the loss of one machine, process, or zone without taking the platform down.
 
+The synthetic demo scenario and reset contract are in
+[`demo/README.md`](demo/README.md).
+
 ## What To Do First
 
 For a new production-like deployment:

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,34 @@
+# Demo Scenario
+
+The fictional **Northstar Paperworks** dataset demonstrates a small publisher
+tracking a product launch, one opportunity, and one meeting decision.
+
+The CSV files are the demo seed contract. Future app adapters should import them
+idempotently using the `demo_*` IDs.
+
+## Walkthrough
+
+1. View the Northstar organization and people.
+2. Open the Aurora launch project.
+3. Review the bookstore partnership opportunity.
+4. Open the launch-review meeting summary.
+5. Follow its decision and action back to the project/opportunity.
+
+This is synthetic data. Never seed from production exports.
+
+## Reset
+
+Reset the disposable sandbox with:
+
+```bash
+scripts/dev-cluster-down.sh
+scripts/dev-smoke.sh platform
+```
+
+App-specific seed adapters are not implemented yet. When added, they must run
+after cluster creation, upsert by `demo_*` ID, and support this reset path.
+
+Validate the dataset with `scripts/test-demo-data.sh`.
+
+Capture screenshots only after adapters render this scenario; placeholders
+would misrepresent current behavior.

--- a/demo/seed/meetings.csv
+++ b/demo/seed/meetings.csv
@@ -1,0 +1,2 @@
+id,project_id,title,summary,decision,action
+demo_meeting_launch_review,demo_project_aurora,Aurora Launch Review,The team reviewed launch readiness,Delay print approval until accessibility review completes,Mara owns the accessibility review

--- a/demo/seed/opportunities.csv
+++ b/demo/seed/opportunities.csv
@@ -1,0 +1,2 @@
+id,organization_id,title,stage,amount_usd
+demo_opportunity_bookstores,demo_org_northstar,Independent Bookstore Partnership,Qualified,12000

--- a/demo/seed/organizations.csv
+++ b/demo/seed/organizations.csv
@@ -1,0 +1,2 @@
+id,name,domain
+demo_org_northstar,Northstar Paperworks,northstar.example.test

--- a/demo/seed/people.csv
+++ b/demo/seed/people.csv
@@ -1,0 +1,3 @@
+id,organization_id,name,email
+demo_person_mara,demo_org_northstar,Mara Chen,mara@northstar.example.test
+demo_person_devon,demo_org_northstar,Devon Reyes,devon@northstar.example.test

--- a/demo/seed/projects.csv
+++ b/demo/seed/projects.csv
@@ -1,0 +1,2 @@
+id,organization_id,name,status
+demo_project_aurora,demo_org_northstar,Aurora Launch,Active

--- a/scripts/test-demo-data.sh
+++ b/scripts/test-demo-data.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+SEED_DIR="${SCRIPT_DIR%/*}/demo/seed"
+
+for name in organizations people projects opportunities meetings; do
+  file="${SEED_DIR}/${name}.csv"
+  [ -s "${file}" ] || {
+    echo "Missing demo seed: ${file}" >&2
+    exit 1
+  }
+  awk -F, 'NR > 1 && $1 !~ /^demo_/ { exit 1 }' "${file}" || {
+    echo "Demo IDs must start with demo_: ${file}" >&2
+    exit 1
+  }
+done
+
+if grep -Eiq \
+  'thekeepstudios|iantsmall|full[[:space:]_-]*hearts|@gmail\.com|@yahoo\.com|@outlook\.com' \
+  "${SEED_DIR}"/*.csv; then
+  echo "Demo seed contains a forbidden real-data marker." >&2
+  exit 1
+fi
+
+if grep -Eiho '[[:alnum:]._%+-]+@[[:alnum:].-]+' "${SEED_DIR}"/*.csv |
+   grep -Ev '@[[:alnum:].-]+\.example\.test$' >/dev/null; then
+  echo "Demo email addresses must use example.test." >&2
+  exit 1
+fi
+
+echo "Demo seed checks passed."

--- a/scripts/test-iac-static.sh
+++ b/scripts/test-iac-static.sh
@@ -38,6 +38,9 @@ while IFS= read -r script; do
   bash -n "${script}"
 done < <(find scripts -maxdepth 1 -type f -name "*.sh" | sort)
 
+log "Synthetic demo data checks"
+scripts/test-demo-data.sh
+
 log "Kustomize render check"
 while IFS= read -r kustomization; do
   dir="$(dirname "${kustomization}")"


### PR DESCRIPTION
## Summary

Adds the smallest safe foundation for #22.

- defines one fictional Northstar Paperworks walkthrough
- adds five tiny CSV seed contracts using stable `demo_*` IDs and `example.test`
- adds a shell privacy/schema guard and runs it from the static IaC suite
- documents the existing disposable k3d reset path
- explicitly marks app-specific seed adapters and real screenshots as unfinished instead of faking them

## Validation

- `scripts/test-demo-data.sh`
- `scripts/test-iac-static.sh`
- `git diff --check`

## Remaining Work

App-specific idempotent seed adapters must import the canonical CSVs after cluster creation. Screenshots should be captured only after those adapters render the scenario. This PR is therefore intentionally draft and does not claim all #22 acceptance criteria are complete.

## Operational Impact

Synthetic files and local validation only. No production/private exports or live systems were accessed.

## Rollback

Revert commit `d536f56`.

## AI Attribution

Prepared autonomously by Codex under `.aiassistant/rules/Autonomous Agent Safety.md`. Human review is required before merge.

Relates to #22