### PR TITLE
Add constrained EspoCRM assistant boundary (#28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ ansible/production_vars.yml
 /ansible/dev_vars.yml
 /.artifacts/
 /.ai/
+__pycache__/
+.venv/
+*.egg-info/

--- a/services/espocrm-assistant/README.md
+++ b/services/espocrm-assistant/README.md
@@ -1,0 +1,36 @@
+# EspoCRM Assistant
+
+Constrained EspoCRM access for issue
+[#28](https://github.com/The-Keep-Studios/thekeep-platform/issues/28).
+The MCP server can read records and prepare signed change sets; it cannot apply
+or delete anything. See the
+[evaluation](../../docs/espocrm-mcp-evaluation.md) for the security boundary.
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+pip install -e .
+export ESPOCRM_URL=https://crm.example.com
+export ESPOCRM_READ_API_KEY=...
+thekeep-espocrm-mcp
+```
+
+Apply a reviewed change set outside the assistant:
+
+```bash
+thekeep-espocrm-apply change.json \
+  --approve-sha256 <sha256> \
+  --approved-by <human-identity>
+```
+
+Use separate read-only and write-capable Espo API users. The executor reads
+`ESPOCRM_WRITE_API_KEY`; optional HMAC secrets use the same `READ_`/`WRITE_`
+prefix. Writes require source attribution; Opportunity writes also require
+reciprocal signal evidence or an explicit human override. The executor rejects
+stale updates, adds an Espo Note, and appends a mode-`0600` local audit record.
+
+Run the dependency-free tests with:
+
+```bash
+PYTHONPATH=src python -m unittest discover -s tests -v
+```

--- a/services/espocrm-assistant/pyproject.toml
+++ b/services/espocrm-assistant/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=75"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "thekeep-espocrm-assistant"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["mcp>=1.14,<2"]
+
+[project.scripts]
+thekeep-espocrm-mcp = "espocrm_assistant.server:main"
+thekeep-espocrm-apply = "espocrm_assistant.apply:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/services/espocrm-assistant/src/espocrm_assistant/__init__.py
+++ b/services/espocrm-assistant/src/espocrm_assistant/__init__.py
@@ -1,0 +1,1 @@
+"""Constrained EspoCRM assistant boundary."""

--- a/services/espocrm-assistant/src/espocrm_assistant/apply.py
+++ b/services/espocrm-assistant/src/espocrm_assistant/apply.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from .client import EspoClient
+from .executor import apply_change
+
+
+def _write_private(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_CREAT | os.O_TRUNC | os.O_WRONLY, 0o600)
+    try:
+        os.write(descriptor, (json.dumps(value, indent=2, sort_keys=True) + "\n").encode())
+    finally:
+        os.close(descriptor)
+    os.chmod(path, 0o600)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Apply one human-approved EspoCRM change set")
+    parser.add_argument("change_set", type=Path)
+    parser.add_argument("--approve-sha256", required=True)
+    parser.add_argument("--approved-by", required=True)
+    parser.add_argument("--report", type=Path)
+    parser.add_argument(
+        "--audit-log",
+        type=Path,
+        default=Path("~/.local/state/thekeep/espocrm-assistant-audit.jsonl").expanduser(),
+    )
+    args = parser.parse_args()
+
+    change = json.loads(args.change_set.read_text())
+    client = EspoClient(
+        os.environ["ESPOCRM_URL"],
+        os.environ["ESPOCRM_WRITE_API_KEY"],
+        secret_key=os.getenv("ESPOCRM_WRITE_SECRET_KEY"),
+        auth_method=os.getenv("ESPOCRM_WRITE_AUTH_METHOD", "apikey"),
+        allow_http=os.getenv("ESPOCRM_ALLOW_HTTP") == "1",
+    )
+    report = apply_change(
+        client,
+        change,
+        approved_sha256=args.approve_sha256,
+        approved_by=args.approved_by,
+        audit_log=args.audit_log,
+    )
+    if args.report:
+        _write_private(args.report, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if report["status"] != "applied":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/espocrm-assistant/src/espocrm_assistant/client.py
+++ b/services/espocrm-assistant/src/espocrm_assistant/client.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping
+from typing import Any
+
+Transport = Callable[
+    [str, str, Mapping[str, str], bytes | None, float],
+    tuple[int, bytes],
+]
+
+
+class EspoError(RuntimeError):
+    pass
+
+
+def _urllib_transport(
+    method: str,
+    url: str,
+    headers: Mapping[str, str],
+    body: bytes | None,
+    timeout: float,
+) -> tuple[int, bytes]:
+    request = urllib.request.Request(url, data=body, headers=dict(headers), method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as error:
+        return error.code, error.read()
+
+
+class EspoClient:
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        *,
+        secret_key: str | None = None,
+        auth_method: str = "apikey",
+        allow_http: bool = False,
+        timeout: float = 30,
+        transport: Transport | None = None,
+    ) -> None:
+        parsed = urllib.parse.urlparse(base_url)
+        if parsed.scheme != "https" and not allow_http:
+            raise ValueError("ESPOCRM_URL must use HTTPS")
+        if not parsed.netloc or not api_key:
+            raise ValueError("EspoCRM URL and API key are required")
+        if auth_method not in {"apikey", "hmac"}:
+            raise ValueError("auth_method must be apikey or hmac")
+        if auth_method == "hmac" and not secret_key:
+            raise ValueError("HMAC authentication requires a secret key")
+
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.secret_key = secret_key
+        self.auth_method = auth_method
+        self.timeout = timeout
+        self.transport = transport or _urllib_transport
+
+    def _auth_headers(self, method: str, action: str) -> dict[str, str]:
+        if self.auth_method == "apikey":
+            return {"X-Api-Key": self.api_key}
+
+        message = f"{method} /{action}".encode()
+        digest = hmac.new(self.secret_key.encode(), message, hashlib.sha256).hexdigest()
+        token = base64.b64encode(f"{self.api_key}:{digest}".encode()).decode()
+        return {"X-Hmac-Authorization": token}
+
+    def request(
+        self,
+        method: str,
+        action: str,
+        *,
+        query: Mapping[str, Any] | None = None,
+        data: Mapping[str, Any] | None = None,
+    ) -> Any:
+        method = method.upper()
+        clean_action = action.strip("/")
+        url = f"{self.base_url}/api/v1/{urllib.parse.quote(clean_action, safe='/')}"
+        if query:
+            url += "?" + urllib.parse.urlencode(query)
+
+        headers = {"Accept": "application/json", **self._auth_headers(method, clean_action)}
+        body = None
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+            body = json.dumps(data, separators=(",", ":")).encode()
+
+        status, payload = self.transport(method, url, headers, body, self.timeout)
+        if status < 200 or status >= 300:
+            detail = payload.decode(errors="replace")[:500]
+            raise EspoError(f"EspoCRM returned HTTP {status}: {detail}")
+        if not payload:
+            return None
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as error:
+            raise EspoError("EspoCRM returned invalid JSON") from error
+
+    def search(self, entity: str, search_params: Mapping[str, Any]) -> Any:
+        params = json.dumps(search_params, sort_keys=True, separators=(",", ":"))
+        return self.request("GET", entity, query={"searchParams": params})
+
+    def get(self, entity: str, record_id: str) -> Any:
+        return self.request("GET", f"{entity}/{record_id}")
+
+    def metadata(self) -> Any:
+        return self.request("GET", "Metadata")
+
+    def create(self, entity: str, fields: Mapping[str, Any]) -> Any:
+        return self.request("POST", entity, data=fields)
+
+    def update(self, entity: str, record_id: str, fields: Mapping[str, Any]) -> Any:
+        return self.request("PUT", f"{entity}/{record_id}", data=fields)

--- a/services/espocrm-assistant/src/espocrm_assistant/executor.py
+++ b/services/espocrm-assistant/src/espocrm_assistant/executor.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .client import EspoClient
+from .policy import PolicyError, validate_change
+from .service import EspoAssistant
+
+
+def _append_audit(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+    try:
+        os.write(descriptor, (json.dumps(report, sort_keys=True) + "\n").encode())
+    finally:
+        os.close(descriptor)
+    os.chmod(path, 0o600)
+
+
+def apply_change(
+    client: EspoClient,
+    change: dict[str, Any],
+    *,
+    approved_sha256: str,
+    approved_by: str,
+    audit_log: Path,
+) -> dict[str, Any]:
+    validate_change(change)
+    if change["sha256"] != approved_sha256:
+        raise PolicyError("approved hash does not match change set")
+    if not approved_by.strip() or len(approved_by) > 200 or "\n" in approved_by:
+        raise PolicyError("approver identity is required")
+
+    report = {
+        "status": "pending",
+        "changeId": change["changeId"],
+        "sha256": change["sha256"],
+        "entity": change["entity"],
+        "recordId": change.get("recordId"),
+        "approvedBy": approved_by,
+        "appliedAt": datetime.now(UTC).isoformat(),
+        "source": change["source"],
+        "before": None,
+        "after": None,
+        "auditNoteId": None,
+    }
+    _append_audit(audit_log, report)
+    wrote = False
+    try:
+        if change["operation"] == "update":
+            before = client.get(change["entity"], change["recordId"])
+            report["before"] = before
+            if before.get("modifiedAt") != change["precondition"]["modifiedAt"]:
+                raise PolicyError("record changed after the change set was prepared")
+            client.update(change["entity"], change["recordId"], change["fields"])
+            record_id = change["recordId"]
+        else:
+            if change["entity"] in {"Lead", "Opportunity"}:
+                current = EspoAssistant(client).duplicate_candidates(change["fields"])
+                approved = {
+                    (item.get("entity"), item.get("id"))
+                    for item in change["duplicateCandidates"]
+                }
+                if any((item["entity"], item["id"]) not in approved for item in current):
+                    raise PolicyError("new duplicate candidate appeared after approval")
+            result = client.create(change["entity"], change["fields"])
+            record_id = result.get("id")
+            if not record_id:
+                raise RuntimeError("EspoCRM create response did not include an ID")
+            report["recordId"] = record_id
+        wrote = True
+
+        report["after"] = client.get(change["entity"], record_id)
+        note = client.create("Note", {
+            "type": "Post",
+            "parentType": change["entity"],
+            "parentId": record_id,
+            "post": (
+                f"{change['auditNote']}\n"
+                f"Approved by {approved_by}; change {change['changeId']}; "
+                f"sha256 {change['sha256']}."
+            ),
+        })
+        report["auditNoteId"] = note.get("id")
+        report["status"] = "applied"
+    except Exception as error:
+        report["status"] = "partial" if wrote else "failed"
+        report["error"] = f"{type(error).__name__}: {error}"
+    finally:
+        _append_audit(audit_log, report)
+    return report

--- a/services/espocrm-assistant/src/espocrm_assistant/policy.py
+++ b/services/espocrm-assistant/src/espocrm_assistant/policy.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+READ_FIELDS = {
+    "Lead": {
+        "id", "name", "firstName", "lastName", "accountName", "emailAddress",
+        "phoneNumber", "title", "website", "status", "source", "description",
+        "createdAt", "modifiedAt", "assignedUserId",
+    },
+    "Opportunity": {
+        "id", "name", "amount", "amountCurrency", "stage", "probability",
+        "closeDate", "accountId", "contactsIds", "leadSource", "description",
+        "createdAt", "modifiedAt", "assignedUserId",
+    },
+    "Account": {
+        "id", "name", "website", "emailAddress", "phoneNumber", "type",
+        "industry", "description", "createdAt", "modifiedAt", "assignedUserId",
+    },
+    "Contact": {
+        "id", "name", "firstName", "lastName", "emailAddress", "phoneNumber",
+        "accountId", "title", "description", "createdAt", "modifiedAt",
+        "assignedUserId",
+    },
+    "Email": {
+        "id", "name", "subject", "from", "to", "cc", "dateSent", "status",
+        "parentId", "parentType", "bodyPlain", "createdAt", "modifiedAt",
+    },
+    "Task": {
+        "id", "name", "status", "priority", "dateStart", "dateEnd",
+        "description", "parentType", "parentId", "createdAt", "modifiedAt",
+        "assignedUserId",
+    },
+}
+
+WRITE_FIELDS = {
+    "Lead": {
+        "firstName", "lastName", "name", "accountName", "emailAddress",
+        "emailAddressData", "phoneNumber", "phoneNumberData", "title", "website",
+        "addressStreet", "addressCity", "addressState", "addressCountry",
+        "addressPostalCode", "status", "source", "opportunityAmount",
+        "opportunityAmountCurrency", "campaignId", "industry", "description",
+        "assignedUserId", "teamsIds",
+    },
+    "Opportunity": {
+        "name", "amount", "amountCurrency", "stage", "probability", "closeDate",
+        "accountId", "contactsIds", "description", "assignedUserId", "teamsIds",
+        "leadSource",
+    },
+    "Task": {
+        "name", "status", "priority", "dateStart", "dateEnd", "dateStartDate",
+        "dateEndDate", "description", "parentType", "parentId", "assignedUserId",
+        "teamsIds",
+    },
+}
+
+SOURCE_TYPES = {
+    "AI Scrape", "Email Recruiter", "LinkedIn", "Slack/Community",
+    "Personal Network", "Direct Company Search", "Manual/Ian Found",
+    "Trello Import", "Unknown",
+}
+FILTER_TYPES = {
+    "equals", "notEquals", "contains", "startsWith", "isNull", "isNotNull",
+    "in", "notIn", "greaterThan", "lessThan", "between",
+}
+_ID = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_CHANGE_KEYS = {
+    "schemaVersion", "changeId", "createdAt", "operation", "entity", "recordId",
+    "fields", "source", "policy", "precondition", "duplicateCandidates",
+    "auditNote", "sha256",
+}
+
+
+class PolicyError(ValueError):
+    pass
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def change_hash(change: dict[str, Any]) -> str:
+    unsigned = {key: value for key, value in change.items() if key != "sha256"}
+    return hashlib.sha256(canonical_json(unsigned).encode()).hexdigest()
+
+
+def validate_record_id(value: str) -> None:
+    if not _ID.fullmatch(value):
+        raise PolicyError("invalid record ID")
+
+
+def validate_filters(entity: str, filters: list[dict[str, Any]]) -> None:
+    if entity not in READ_FIELDS:
+        raise PolicyError("entity is not readable")
+    if len(filters) > 8:
+        raise PolicyError("at most eight filters are allowed")
+    for item in filters:
+        if item.get("type") not in FILTER_TYPES:
+            raise PolicyError("filter type is not allowed")
+        if item.get("attribute") not in READ_FIELDS[entity]:
+            raise PolicyError("filter field is not allowed")
+        if len(canonical_json(item.get("value"))) > 500:
+            raise PolicyError("filter value is too large")
+
+
+def prepare_change(
+    *,
+    operation: str,
+    entity: str,
+    fields: dict[str, Any],
+    source: dict[str, Any],
+    record_id: str | None = None,
+    expected_modified_at: str | None = None,
+    reciprocal_signal: str | None = None,
+    opportunity_override: str | None = None,
+    duplicate_candidates: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    if operation not in {"create", "update"}:
+        raise PolicyError("only create and update operations are allowed")
+    if entity not in WRITE_FIELDS:
+        raise PolicyError("entity is not writable")
+    if not isinstance(fields, dict) or not fields or set(fields) - WRITE_FIELDS[entity]:
+        raise PolicyError("fields contain an empty or disallowed write")
+    if len(canonical_json(fields)) > 100_000:
+        raise PolicyError("write payload is too large")
+    if not isinstance(source, dict) or source.get("type") not in SOURCE_TYPES:
+        raise PolicyError("source type and reference are required")
+    if not str(source.get("reference", "")).strip() or len(str(source["reference"])) > 2_000:
+        raise PolicyError("source type and reference are required")
+
+    if operation == "update":
+        if not record_id or not expected_modified_at:
+            raise PolicyError("updates require record ID and modifiedAt precondition")
+        validate_record_id(record_id)
+    elif record_id or expected_modified_at:
+        raise PolicyError("create cannot include update preconditions")
+
+    if entity == "Opportunity" and not (
+        str(reciprocal_signal or "").strip() or str(opportunity_override or "").strip()
+    ):
+        raise PolicyError("Opportunity writes require reciprocal signal or explicit override")
+    if operation == "create" and entity == "Opportunity" and not fields.get("name"):
+        raise PolicyError("Opportunity creates require a name")
+    if operation == "create" and entity == "Lead" and not any(
+        fields.get(key) for key in ("name", "firstName", "lastName", "emailAddress", "accountName", "website")
+    ):
+        raise PolicyError("Lead creates require identifying fields")
+    if entity == "Task":
+        if operation != "create":
+            raise PolicyError("Task updates are not exposed")
+        if fields.get("parentType") not in {"Lead", "Opportunity"} or not fields.get("parentId"):
+            raise PolicyError("Task must link to a Lead or Opportunity")
+        validate_record_id(str(fields["parentId"]))
+
+    change = {
+        "schemaVersion": 1,
+        "changeId": str(uuid.uuid4()),
+        "createdAt": datetime.now(UTC).isoformat(),
+        "operation": operation,
+        "entity": entity,
+        "recordId": record_id,
+        "fields": fields,
+        "source": source,
+        "policy": {
+            "reciprocalSignal": reciprocal_signal,
+            "explicitOpportunityOverride": opportunity_override,
+        },
+        "precondition": {"modifiedAt": expected_modified_at},
+        "duplicateCandidates": duplicate_candidates or [],
+        "auditNote": f"Prepared by The Keep assistant from {source['type']}: {source['reference']}",
+    }
+    change["sha256"] = change_hash(change)
+    return change
+
+
+def validate_change(change: dict[str, Any]) -> None:
+    if set(change) != _CHANGE_KEYS or change.get("schemaVersion") != 1:
+        raise PolicyError("change-set shape is invalid")
+    if change.get("sha256") != change_hash(change):
+        raise PolicyError("change-set hash is invalid")
+    try:
+        uuid.UUID(change["changeId"])
+        created_at = datetime.fromisoformat(change["createdAt"])
+        if created_at.tzinfo is None:
+            raise ValueError("createdAt requires timezone")
+        expected = prepare_change(
+            operation=change["operation"],
+            entity=change["entity"],
+            fields=change["fields"],
+            source=change["source"],
+            record_id=change["recordId"],
+            expected_modified_at=change["precondition"]["modifiedAt"],
+            reciprocal_signal=change["policy"]["reciprocalSignal"],
+            opportunity_override=change["policy"]["explicitOpportunityOverride"],
+            duplicate_candidates=change["duplicateCandidates"],
+        )
+    except (AttributeError, KeyError, TypeError, ValueError) as error:
+        raise PolicyError("change-set content is invalid") from error
+    for key in (
+        "operation", "entity", "recordId", "fields", "source", "policy",
+        "precondition", "duplicateCandidates", "auditNote",
+    ):
+        if change.get(key) != expected.get(key):
+            raise PolicyError("change-set content is invalid")
+
+
+def export_csv(changes: list[dict[str, Any]]) -> str:
+    output = io.StringIO()
+    writer = csv.DictWriter(
+        output,
+        fieldnames=[
+            "operation", "entity", "recordId", "sha256", "sourceType",
+            "sourceReference", "fieldsJson",
+        ],
+    )
+    writer.writeheader()
+    for change in changes:
+        validate_change(change)
+        writer.writerow({
+            "operation": change["operation"],
+            "entity": change["entity"],
+            "recordId": change["recordId"] or "",
+            "sha256": change["sha256"],
+            "sourceType": change["source"]["type"],
+            "sourceReference": change["source"]["reference"],
+            "fieldsJson": canonical_json(change["fields"]),
+        })
+    return output.getvalue()

--- a/services/espocrm-assistant/src/espocrm_assistant/server.py
+++ b/services/espocrm-assistant/src/espocrm_assistant/server.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from .client import EspoClient
+from .service import EspoAssistant
+
+mcp = FastMCP("thekeep-espocrm")
+_service: EspoAssistant | None = None
+
+
+def service() -> EspoAssistant:
+    global _service
+    if _service is None:
+        _service = EspoAssistant(EspoClient(
+            os.environ["ESPOCRM_URL"],
+            os.environ["ESPOCRM_READ_API_KEY"],
+            secret_key=os.getenv("ESPOCRM_READ_SECRET_KEY"),
+            auth_method=os.getenv("ESPOCRM_READ_AUTH_METHOD", "apikey"),
+            allow_http=os.getenv("ESPOCRM_ALLOW_HTTP") == "1",
+        ))
+    return _service
+
+
+@mcp.tool()
+def crm_search(
+    entity: str,
+    filters: list[dict[str, Any]] | None = None,
+    text: str | None = None,
+    fields: list[str] | None = None,
+    limit: int = 20,
+) -> Any:
+    """Search allowlisted CRM records without mutation."""
+    return service().search(entity, filters=filters, text=text, fields=fields, limit=limit)
+
+
+@mcp.tool()
+def crm_get(entity: str, record_id: str, fields: list[str] | None = None) -> Any:
+    """Read one allowlisted CRM record."""
+    return service().get(entity, record_id, fields)
+
+
+@mcp.tool()
+def crm_metadata(entity: str) -> Any:
+    """Read allowlisted field metadata for one entity."""
+    return service().metadata(entity)
+
+
+@mcp.tool()
+def crm_duplicate_candidates(fields: dict[str, Any]) -> Any:
+    """Find possible duplicates from identifying fields."""
+    return service().duplicate_candidates(fields)
+
+
+@mcp.tool()
+def crm_prepare_change(request: dict[str, Any]) -> Any:
+    """Prepare and hash a non-mutating create or update change set."""
+    return service().prepare_change(**request)
+
+
+@mcp.tool()
+def crm_export_csv(changes: list[dict[str, Any]]) -> str:
+    """Export validated change sets as CSV for manual import."""
+    return service().export_csv(changes)
+
+
+def main() -> None:
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/espocrm-assistant/src/espocrm_assistant/service.py
+++ b/services/espocrm-assistant/src/espocrm_assistant/service.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .client import EspoClient
+from .policy import READ_FIELDS, PolicyError, export_csv, prepare_change, validate_filters
+
+
+def _bounded(value: Any) -> Any:
+    if isinstance(value, str):
+        return value[:20_000]
+    if isinstance(value, list):
+        return value[:100]
+    return value
+
+
+class EspoAssistant:
+    def __init__(self, client: EspoClient) -> None:
+        self.client = client
+
+    def search(
+        self,
+        entity: str,
+        *,
+        filters: list[dict[str, Any]] | None = None,
+        text: str | None = None,
+        fields: list[str] | None = None,
+        limit: int = 20,
+    ) -> Any:
+        filters = filters or []
+        validate_filters(entity, filters)
+        selected = fields or sorted(READ_FIELDS[entity])
+        if not 1 <= limit <= 50 or set(selected) - READ_FIELDS[entity]:
+            raise PolicyError("invalid field selection or result limit")
+        params: dict[str, Any] = {
+            "where": filters,
+            "maxSize": limit,
+            "select": selected,
+        }
+        if text:
+            params["textFilter"] = text[:200]
+        response = self.client.search(entity, params)
+        return {
+            "total": response.get("total"),
+            "list": [
+                {key: _bounded(value) for key, value in record.items() if key in selected}
+                for record in response.get("list", [])
+            ],
+        }
+
+    def get(self, entity: str, record_id: str, fields: list[str] | None = None) -> dict[str, Any]:
+        from .policy import validate_record_id
+
+        validate_record_id(record_id)
+        selected = set(fields or READ_FIELDS.get(entity, set()))
+        if entity not in READ_FIELDS or selected - READ_FIELDS[entity]:
+            raise PolicyError("invalid entity or field selection")
+        record = self.client.get(entity, record_id)
+        return {key: _bounded(value) for key, value in record.items() if key in selected}
+
+    def metadata(self, entity: str) -> dict[str, Any]:
+        if entity not in READ_FIELDS:
+            raise PolicyError("entity is not readable")
+        fields = self.client.metadata().get("entityDefs", {}).get(entity, {}).get("fields", {})
+        return {
+            name: {
+                key: value for key, value in definition.items()
+                if key in {"type", "required", "options", "default"}
+            }
+            for name, definition in fields.items()
+            if name in READ_FIELDS[entity]
+        }
+
+    def duplicate_candidates(self, fields: dict[str, Any]) -> list[dict[str, Any]]:
+        searches = []
+        for entity, attribute, match, value in (
+            ("Lead", "emailAddress", "equals", fields.get("emailAddress")),
+            ("Contact", "emailAddress", "equals", fields.get("emailAddress")),
+            ("Lead", "accountName", "contains", fields.get("accountName")),
+            ("Account", "name", "contains", fields.get("accountName")),
+            ("Lead", "website", "equals", fields.get("website") or fields.get("sourceUrl")),
+            ("Account", "website", "equals", fields.get("website")),
+            ("Lead", "name", "contains", fields.get("name")),
+            ("Opportunity", "name", "contains", fields.get("name")),
+        ):
+            if value:
+                searches.append((entity, attribute, match, value))
+
+        found: dict[tuple[str, str], dict[str, Any]] = {}
+        for entity, attribute, match, value in searches[:8]:
+            response = self.search(
+                entity,
+                filters=[{"type": match, "attribute": attribute, "value": str(value)[:200]}],
+                fields=["id", "name", "modifiedAt"],
+                limit=10,
+            )
+            for record in response.get("list", []):
+                if record.get("id"):
+                    found[(entity, record["id"])] = {
+                        "entity": entity,
+                        "id": record["id"],
+                        "name": record.get("name"),
+                        "matchedOn": attribute,
+                    }
+        return list(found.values())
+
+    def prepare_change(self, **request: Any) -> dict[str, Any]:
+        candidates = (
+            self.duplicate_candidates(request["fields"])
+            if request["operation"] == "create" and request["entity"] in {"Lead", "Opportunity"}
+            else []
+        )
+        return prepare_change(**request, duplicate_candidates=candidates)
+
+    @staticmethod
+    def export_csv(changes: list[dict[str, Any]]) -> str:
+        return export_csv(changes)

--- a/services/espocrm-assistant/tests/test_assistant.py
+++ b/services/espocrm-assistant/tests/test_assistant.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from espocrm_assistant.client import EspoClient
+from espocrm_assistant.executor import apply_change
+from espocrm_assistant.policy import PolicyError, export_csv, prepare_change
+from espocrm_assistant.service import EspoAssistant
+
+
+def source(kind: str = "LinkedIn") -> dict[str, str]:
+    return {"type": kind, "reference": "https://example.test/source/1"}
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.records = {}
+        self.created = []
+
+    def get(self, entity, record_id):
+        return self.records[(entity, record_id)].copy()
+
+    def create(self, entity, fields):
+        record_id = f"id-{len(self.created) + 1}"
+        record = {"id": record_id, "modifiedAt": "2026-06-11 12:00:00", **fields}
+        self.created.append((entity, fields.copy()))
+        self.records[(entity, record_id)] = record
+        return record.copy()
+
+    def update(self, entity, record_id, fields):
+        self.records[(entity, record_id)].update(fields)
+        return self.records[(entity, record_id)].copy()
+
+    def search(self, entity, params):
+        where = params["where"][0]
+        needle = str(where["value"]).lower()
+        found = []
+        for (record_entity, _), record in self.records.items():
+            value = str(record.get(where["attribute"], "")).lower()
+            if record_entity == entity and (
+                value == needle if where["type"] == "equals" else needle in value
+            ):
+                found.append(record.copy())
+        return {"total": len(found), "list": found[:params["maxSize"]]}
+
+
+class ClientTests(unittest.TestCase):
+    def test_https_is_required(self):
+        with self.assertRaisesRegex(ValueError, "HTTPS"):
+            EspoClient("http://crm.test", "key")
+
+    def test_hmac_header_matches_espo_scheme(self):
+        captured = {}
+
+        def transport(method, url, headers, body, timeout):
+            captured.update(headers)
+            return 200, b"{}"
+
+        client = EspoClient(
+            "https://crm.test", "key", secret_key="secret",
+            auth_method="hmac", transport=transport,
+        )
+        client.get("Lead", "abc")
+        digest = hmac.new(b"secret", b"GET /Lead/abc", hashlib.sha256).hexdigest()
+        expected = base64.b64encode(f"key:{digest}".encode()).decode()
+        self.assertEqual(expected, captured["X-Hmac-Authorization"])
+        self.assertNotIn("X-Api-Key", captured)
+
+
+class PolicyTests(unittest.TestCase):
+    def test_delete_and_disallowed_fields_are_rejected(self):
+        with self.assertRaises(PolicyError):
+            prepare_change(operation="delete", entity="Lead", fields={"name": "x"}, source=source())
+        with self.assertRaises(PolicyError):
+            prepare_change(operation="create", entity="Lead", fields={"portalUser": True}, source=source())
+
+    def test_opportunity_requires_reciprocal_signal_or_override(self):
+        with self.assertRaisesRegex(PolicyError, "reciprocal"):
+            prepare_change(
+                operation="create", entity="Opportunity",
+                fields={"name": "Unanswered listing"}, source=source(),
+            )
+        change = prepare_change(
+            operation="create", entity="Opportunity",
+            fields={"name": "Recruiter replied"}, source=source(),
+            reciprocal_signal="Recruiter requested an interview.",
+        )
+        self.assertEqual("Opportunity", change["entity"])
+
+    def test_updates_require_precondition(self):
+        with self.assertRaisesRegex(PolicyError, "precondition"):
+            prepare_change(
+                operation="update", entity="Lead", record_id="lead-1",
+                fields={"status": "Dead"}, source=source(),
+            )
+
+    def test_task_must_be_linked(self):
+        with self.assertRaisesRegex(PolicyError, "link"):
+            prepare_change(
+                operation="create", entity="Task",
+                fields={"name": "Follow up"}, source=source(),
+            )
+
+    def test_csv_contains_validated_change(self):
+        change = prepare_change(
+            operation="create", entity="Lead",
+            fields={"name": "Platform role"}, source=source(),
+        )
+        output = export_csv([change])
+        self.assertIn(change["sha256"], output)
+        self.assertIn("Platform role", output)
+
+    def test_change_shape_and_hash_are_revalidated(self):
+        change = prepare_change(
+            operation="create", entity="Lead",
+            fields={"name": "Platform role"}, source=source(),
+        )
+        change["unexpected"] = True
+        change["sha256"] = hashlib.sha256(
+            json.dumps(
+                {key: value for key, value in change.items() if key != "sha256"},
+                sort_keys=True, separators=(",", ":"),
+            ).encode()
+        ).hexdigest()
+        with self.assertRaisesRegex(PolicyError, "shape"):
+            export_csv([change])
+
+    def test_issue_fixtures_follow_lead_opportunity_policy(self):
+        fixtures = [
+            ("LinkedIn batch", "Lead", {"name": "Imported role"}, {}, "LinkedIn"),
+            ("ATS confirmation", "Lead", {"name": "Applied role", "status": "Assigned"}, {}, "Unknown"),
+            ("Recruiter outreach", "Opportunity", {"name": "Recruiter screen"}, {"reciprocal_signal": "Recruiter replied."}, "Email Recruiter"),
+            ("Rejected onsite", "Lead", {"name": "Onsite role", "status": "Dead"}, {}, "Manual/Ian Found"),
+            ("Warm consulting", "Opportunity", {"name": "Consulting lead"}, {"reciprocal_signal": "Client requested scope."}, "Personal Network"),
+        ]
+        for label, entity, fields, policy, source_type in fixtures:
+            with self.subTest(label):
+                change = prepare_change(
+                    operation="create", entity=entity, fields=fields,
+                    source=source(source_type), **policy,
+                )
+                self.assertEqual(entity, change["entity"])
+
+
+class ServiceTests(unittest.TestCase):
+    def test_search_uses_espo_select_array(self):
+        captured = {}
+
+        class SearchClient:
+            def search(self, entity, params):
+                captured.update(params)
+                return {"total": 0, "list": []}
+
+        EspoAssistant(SearchClient()).search("Lead", fields=["id", "name"])
+        self.assertEqual(["id", "name"], captured["select"])
+
+    def test_duplicate_candidates_are_deduplicated(self):
+        class SearchClient:
+            def search(self, entity, params):
+                return {"total": 1, "list": [{"id": "same", "name": "Acme", "secret": "no"}]}
+
+        found = EspoAssistant(SearchClient()).duplicate_candidates({
+            "name": "Acme", "accountName": "Acme",
+        })
+        self.assertEqual(len({(item["entity"], item["id"]) for item in found}), len(found))
+        self.assertNotIn("secret", found[0])
+
+
+class ExecutorTests(unittest.TestCase):
+    def test_stale_update_is_not_written(self):
+        client = FakeClient()
+        client.records[("Lead", "lead-1")] = {"id": "lead-1", "modifiedAt": "new"}
+        change = prepare_change(
+            operation="update", entity="Lead", record_id="lead-1",
+            expected_modified_at="old", fields={"status": "Dead"}, source=source(),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            report = apply_change(
+                client, change, approved_sha256=change["sha256"],
+                approved_by="human@example.test", audit_log=Path(directory) / "audit.jsonl",
+            )
+        self.assertEqual("failed", report["status"])
+        self.assertEqual([], client.created)
+
+    def test_approved_create_writes_record_note_and_private_audit(self):
+        client = FakeClient()
+        change = prepare_change(
+            operation="create", entity="Lead",
+            fields={"name": "Qualified lead"}, source=source(),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            audit = Path(directory) / "audit.jsonl"
+            report = apply_change(
+                client, change, approved_sha256=change["sha256"],
+                approved_by="human@example.test", audit_log=audit,
+            )
+            saved = [json.loads(line) for line in audit.read_text().splitlines()]
+            self.assertEqual(0o600, audit.stat().st_mode & 0o777)
+        self.assertEqual("applied", report["status"])
+        self.assertEqual(["Lead", "Note"], [entity for entity, _ in client.created])
+        self.assertEqual(["pending", "applied"], [entry["status"] for entry in saved])
+        self.assertEqual(change["sha256"], saved[-1]["sha256"])
+
+    def test_new_duplicate_blocks_create(self):
+        client = FakeClient()
+        change = prepare_change(
+            operation="create", entity="Lead",
+            fields={"name": "Qualified lead"}, source=source(),
+        )
+        client.records[("Lead", "lead-existing")] = {
+            "id": "lead-existing", "name": "Qualified lead", "modifiedAt": "now",
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            report = apply_change(
+                client, change, approved_sha256=change["sha256"],
+                approved_by="human@example.test", audit_log=Path(directory) / "audit.jsonl",
+            )
+        self.assertEqual("failed", report["status"])
+        self.assertEqual([], client.created)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
AI-authored draft for #28. Depends on #42; retarget to `main` after #42 merges.

## Scope
- Adds six bounded MCP tools for read, metadata, duplicate checks, dry-run change sets, and CSV export.
- Keeps writes outside MCP in a human-invoked executor requiring the approved SHA-256 and approver identity.
- Enforces no-delete, field/entity allowlists, stale-update checks, source attribution, Opportunity reciprocal-signal/override policy, apply-time duplicate checks, Espo audit notes, and private local audit records.
- Uses separate read-only and write-capable Espo API credentials. No deployment or live CRM access is included.

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (14 passed)
- `python3 -m compileall -q src tests`
- TOML parse and `git diff --check`
- Wheel build not run: this host lacks `setuptools.build_meta`, and no tooling was installed during the autonomous run.

## Assumptions / gaps
- Espo field names must be confirmed against the private instance metadata before rollout.
- MCP runtime and live Espo integration remain untested until a human provides isolated credentials and approves that validation.

Operational impact: none until installed and configured. Rollback: remove/disable the MCP command and executor; this PR changes no CRM or platform state.