### PR TITLE
Lock production GitOps to v0.1.0-alpha.1

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -33,7 +33,7 @@ k3s_version: "v1.35.3+k3s1"
 
 # GitOps Configuration
 gitops_repo_url: "https://github.com/The-Keep-Studios/thekeep-platform.git"
-gitops_revision: "main"
+gitops_revision: "v0.1.0-alpha.1"
 gitops_repo_private: false
 # If gitops_repo_private is true, provide credentials in ansible/production_vars.yml:
 #   gitops_repo_ssh_private_key: "...", or

--- a/kubernetes/gitops/apps/platform-applications.yaml
+++ b/kubernetes/gitops/apps/platform-applications.yaml
@@ -7,7 +7,7 @@ spec:
   project: platform
   source:
     repoURL: "https://github.com/The-Keep-Studios/thekeep-platform.git"
-    targetRevision: "main"
+    targetRevision: "v0.1.0-alpha.1"
     path: kubernetes/platform/cloudflared
   destination:
     server: https://kubernetes.default.svc
@@ -28,7 +28,7 @@ spec:
   project: platform
   source:
     repoURL: "https://github.com/The-Keep-Studios/thekeep-platform.git"
-    targetRevision: "main"
+    targetRevision: "v0.1.0-alpha.1"
     path: kubernetes/platform/authentik
   destination:
     server: https://kubernetes.default.svc
@@ -50,7 +50,7 @@ spec:
   project: platform
   source:
     repoURL: "https://github.com/The-Keep-Studios/thekeep-platform.git"
-    targetRevision: "main"
+    targetRevision: "v0.1.0-alpha.1"
     path: kubernetes/apps/leantime
   destination:
     server: https://kubernetes.default.svc
@@ -72,7 +72,7 @@ spec:
   project: platform
   source:
     repoURL: "https://github.com/The-Keep-Studios/thekeep-platform.git"
-    targetRevision: "main"
+    targetRevision: "v0.1.0-alpha.1"
     path: kubernetes/apps/wisemapping
   destination:
     server: https://kubernetes.default.svc
@@ -94,7 +94,7 @@ spec:
   project: platform
   source:
     repoURL: "https://github.com/The-Keep-Studios/thekeep-platform.git"
-    targetRevision: "main"
+    targetRevision: "v0.1.0-alpha.1"
     path: kubernetes/apps/baserow
   destination:
     server: https://kubernetes.default.svc
@@ -123,10 +123,10 @@ spec:
       valueFiles:
       - $values/kubernetes/platform/monitoring/kube-prometheus-stack.values.yaml
   - repoURL: "https://github.com/The-Keep-Studios/thekeep-platform.git"
-    targetRevision: "main"
+    targetRevision: "v0.1.0-alpha.1"
     ref: values
   - repoURL: "https://github.com/The-Keep-Studios/thekeep-platform.git"
-    targetRevision: "main"
+    targetRevision: "v0.1.0-alpha.1"
     path: kubernetes/platform/monitoring/access
   destination:
     server: https://kubernetes.default.svc
@@ -162,7 +162,7 @@ spec:
       valueFiles:
       - $values/kubernetes/platform/monitoring/promtail.values.yaml
   - repoURL: "https://github.com/The-Keep-Studios/thekeep-platform.git"
-    targetRevision: "main"
+    targetRevision: "v0.1.0-alpha.1"
     ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/kubernetes/gitops/root/platform-root.application.yaml
+++ b/kubernetes/gitops/root/platform-root.application.yaml
@@ -7,7 +7,7 @@ spec:
   project: platform
   source:
     repoURL: "https://github.com/The-Keep-Studios/thekeep-platform.git"
-    targetRevision: "main"
+    targetRevision: "v0.1.0-alpha.1"
     path: kubernetes/gitops/apps
     directory:
       recurse: true


### PR DESCRIPTION
## Summary

- lock the default production GitOps revision to `v0.1.0-alpha.1`
- point the committed Argo CD root app at `v0.1.0-alpha.1`
- point all in-repo Argo CD application sources at `v0.1.0-alpha.1`

## Validation

- `git diff --check`
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-playbook --syntax-check -i ansible/inventory.production.ini.example ansible/setup_k3s_production.yml`

## Release Flow

After this PR merges, create GitHub prerelease `v0.1.0-alpha.1` from the resulting `main` merge commit. That keeps the release tag and the production GitOps lock on the same commit.

## Automation Attribution

Prepared by an AI-assisted automation agent using the current maintainer-authenticated GitHub identity. Human review is required before merge.