### PR TITLE
Add install and demo validation tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Future target:
 
 HA means high availability: the system can survive the loss of one machine, process, or zone without taking the platform down.
 
+The synthetic demo scenario and reset contract are in
+[`demo/README.md`](demo/README.md).
+
 ## What To Do First
 
 For local review without creating a cluster:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ HA means high availability: the system can survive the loss of one machine, proc
 
 ## What To Do First
 
+For local review without creating a cluster:
+
+```bash
+scripts/check-local-prereqs.sh static
+ansible-playbook -i ansible/inventory.ini ansible/setup_dev_environment.yml \
+  -e local_dev_profile=static
+```
+
+For the disposable local k3d sandbox:
+
+```bash
+scripts/check-local-prereqs.sh sandbox
+ansible-playbook -i ansible/inventory.ini ansible/setup_dev_environment.yml
+```
+
+See [`docs/local-iac-testing.md`](docs/local-iac-testing.md) for profiles,
+observation, cleanup, and troubleshooting.
+
 For a new production-like deployment:
 
 1. Copy `ansible/inventory.production.ini.example` to `ansible/inventory.production.ini`.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,34 @@
+# Demo Scenario
+
+The fictional **Northstar Paperworks** dataset demonstrates a small publisher
+tracking a product launch, one opportunity, and one meeting decision.
+
+The CSV files are the demo seed contract. Future app adapters should import them
+idempotently using the `demo_*` IDs.
+
+## Walkthrough
+
+1. View the Northstar organization and people.
+2. Open the Aurora launch project.
+3. Review the bookstore partnership opportunity.
+4. Open the launch-review meeting summary.
+5. Follow its decision and action back to the project/opportunity.
+
+This is synthetic data. Never seed from production exports.
+
+## Reset
+
+Reset the disposable sandbox with:
+
+```bash
+scripts/dev-cluster-down.sh
+scripts/dev-smoke.sh platform
+```
+
+App-specific seed adapters are not implemented yet. When added, they must run
+after cluster creation, upsert by `demo_*` ID, and support this reset path.
+
+Validate the dataset with `scripts/test-demo-data.sh`.
+
+Capture screenshots only after adapters render this scenario; placeholders
+would misrepresent current behavior.

--- a/demo/seed/meetings.csv
+++ b/demo/seed/meetings.csv
@@ -1,0 +1,2 @@
+id,project_id,title,summary,decision,action
+demo_meeting_launch_review,demo_project_aurora,Aurora Launch Review,The team reviewed launch readiness,Delay print approval until accessibility review completes,Mara owns the accessibility review

--- a/demo/seed/opportunities.csv
+++ b/demo/seed/opportunities.csv
@@ -1,0 +1,2 @@
+id,organization_id,title,stage,amount_usd
+demo_opportunity_bookstores,demo_org_northstar,Independent Bookstore Partnership,Qualified,12000

--- a/demo/seed/organizations.csv
+++ b/demo/seed/organizations.csv
@@ -1,0 +1,2 @@
+id,name,domain
+demo_org_northstar,Northstar Paperworks,northstar.example.test

--- a/demo/seed/people.csv
+++ b/demo/seed/people.csv
@@ -1,0 +1,3 @@
+id,organization_id,name,email
+demo_person_mara,demo_org_northstar,Mara Chen,mara@northstar.example.test
+demo_person_devon,demo_org_northstar,Devon Reyes,devon@northstar.example.test

--- a/demo/seed/projects.csv
+++ b/demo/seed/projects.csv
@@ -1,0 +1,2 @@
+id,organization_id,name,status
+demo_project_aurora,demo_org_northstar,Aurora Launch,Active

--- a/docs/local-iac-testing.md
+++ b/docs/local-iac-testing.md
@@ -18,6 +18,16 @@ The local path has three layers:
   requires at least 80 GiB and 8% free on the repo filesystem.
 - Optional: `kubeconform` or `kubeval` for stricter rendered manifest validation.
 
+Check the intended path before running it:
+
+```bash
+scripts/check-local-prereqs.sh static
+scripts/check-local-prereqs.sh sandbox
+```
+
+`static` requires Git, Bash, kubectl, and Ansible. `sandbox` additionally
+requires a working Docker daemon and k3d. The checker is read-only.
+
 ## Static Checks
 
 Run:
@@ -94,6 +104,9 @@ cp ansible/dev_vars.yml.example ansible/dev_vars.yml
 ```
 
 `ansible/dev_vars.yml` is ignored by Git.
+
+This file documents supported environment overrides. Prefer it over adding
+another `.env` or Compose configuration path.
 
 ## Disposable k3s Cluster
 
@@ -330,6 +343,10 @@ DEV_OBSERVE_PATCH_CONFIG=false scripts/dev-observe.sh wisemapping
 
 This local path does not replace production validation.
 
+The k3d path is the current sandbox/demo setup for reviewers. It uses
+deterministic development-only secrets, but it is not the planned public demo
+experience and must not use production exports.
+
 It does not test:
 
 - Cloudflare Tunnel.
@@ -340,3 +357,12 @@ It does not test:
 - Production backup and restore gates.
 
 Use it to catch render errors, startup failures, and service-level smoke test failures before pushing a branch to Argo CD.
+
+Common failures:
+
+- missing command: install the named prerequisite and rerun the checker;
+- Docker unavailable: make `docker info` work without sudo;
+- disk/pressure failure: free space, then recreate the disposable cluster;
+- image pull/network failure: retry after registry/network recovery;
+- port conflict during observation: use the documented `*_OBSERVE_PORT`
+  override.

--- a/scripts/check-local-prereqs.sh
+++ b/scripts/check-local-prereqs.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR%/*}"
+MODE="${1:-sandbox}"
+
+usage() {
+  echo "Usage: $0 [static|sandbox]"
+}
+
+case "${MODE}" in
+  static)
+    required=(git bash kubectl ansible-playbook)
+    ;;
+  sandbox)
+    required=(git bash kubectl ansible-playbook docker k3d)
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+missing=()
+for command_name in "${required[@]}"; do
+  command -v "${command_name}" >/dev/null 2>&1 || missing+=("${command_name}")
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  printf 'Missing required commands: %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+
+if [ "${MODE}" = "sandbox" ] &&
+   [ "${LOCAL_PREREQ_SKIP_DOCKER_INFO:-false}" != "true" ] &&
+   ! docker info >/dev/null 2>&1; then
+  echo "Docker is installed but unavailable to this user." >&2
+  echo "Start Docker and verify that 'docker info' works without sudo." >&2
+  exit 1
+fi
+
+if [ "${LOCAL_PREREQ_SKIP_DISK:-false}" != "true" ]; then
+  # shellcheck source=scripts/dev-preflight.sh
+  source "${SCRIPT_DIR}/dev-preflight.sh"
+  dev_preflight_check_disk "${PROJECT_ROOT}"
+fi
+
+echo "Local ${MODE} prerequisites passed."
+if [ "${MODE}" = "static" ]; then
+  echo "Next: ansible-playbook -i ansible/inventory.ini ansible/setup_dev_environment.yml -e local_dev_profile=static"
+else
+  echo "Next: ansible-playbook -i ansible/inventory.ini ansible/setup_dev_environment.yml"
+fi

--- a/scripts/test-demo-data.sh
+++ b/scripts/test-demo-data.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+SEED_DIR="${SCRIPT_DIR%/*}/demo/seed"
+
+for name in organizations people projects opportunities meetings; do
+  file="${SEED_DIR}/${name}.csv"
+  [ -s "${file}" ] || {
+    echo "Missing demo seed: ${file}" >&2
+    exit 1
+  }
+  awk -F, 'NR > 1 && $1 !~ /^demo_/ { exit 1 }' "${file}" || {
+    echo "Demo IDs must start with demo_: ${file}" >&2
+    exit 1
+  }
+done
+
+if grep -Eiq \
+  'thekeepstudios|iantsmall|full[[:space:]_-]*hearts|@gmail\.com|@yahoo\.com|@outlook\.com' \
+  "${SEED_DIR}"/*.csv; then
+  echo "Demo seed contains a forbidden real-data marker." >&2
+  exit 1
+fi
+
+if grep -Eiho '[[:alnum:]._%+-]+@[[:alnum:].-]+' "${SEED_DIR}"/*.csv |
+   grep -Ev '@[[:alnum:].-]+\.example\.test$' >/dev/null; then
+  echo "Demo email addresses must use example.test." >&2
+  exit 1
+fi
+
+echo "Demo seed checks passed."

--- a/scripts/test-iac-static.sh
+++ b/scripts/test-iac-static.sh
@@ -38,6 +38,9 @@ while IFS= read -r script; do
   bash -n "${script}"
 done < <(find scripts -maxdepth 1 -type f -name "*.sh" | sort)
 
+log "Local prerequisite checker tests"
+scripts/test-local-prereqs.sh
+
 log "Kustomize render check"
 while IFS= read -r kustomization; do
   dir="$(dirname "${kustomization}")"

--- a/scripts/test-iac-static.sh
+++ b/scripts/test-iac-static.sh
@@ -41,6 +41,9 @@ done < <(find scripts -maxdepth 1 -type f -name "*.sh" | sort)
 log "Local prerequisite checker tests"
 scripts/test-local-prereqs.sh
 
+log "Synthetic demo data checks"
+scripts/test-demo-data.sh
+
 log "Kustomize render check"
 while IFS= read -r kustomization; do
   dir="$(dirname "${kustomization}")"

--- a/scripts/test-local-prereqs.sh
+++ b/scripts/test-local-prereqs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/local-prereqs-test.XXXXXX")"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+make_stub() {
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${tmp_dir}/$1"
+  chmod +x "${tmp_dir}/$1"
+}
+
+for name in git bash kubectl ansible-playbook docker k3d; do
+  make_stub "${name}"
+done
+
+PATH="${tmp_dir}" \
+LOCAL_PREREQ_SKIP_DISK=true \
+LOCAL_PREREQ_SKIP_DOCKER_INFO=true \
+  /bin/bash "${SCRIPT_DIR}/check-local-prereqs.sh" sandbox >/dev/null
+
+mv "${tmp_dir}/kubectl" "${tmp_dir}/kubectl.disabled"
+if PATH="${tmp_dir}" LOCAL_PREREQ_SKIP_DISK=true \
+   /bin/bash "${SCRIPT_DIR}/check-local-prereqs.sh" static >/dev/null 2>&1; then
+  echo "Missing kubectl was accepted unexpectedly" >&2
+  exit 1
+fi
+
+echo "Local prerequisite checker tests passed."


### PR DESCRIPTION
## Summary

- adds a local prerequisite checker for static and sandbox setup modes
- adds tests for the prerequisite checker
- adds synthetic demo seed CSVs and validation
- wires both checks into the static IaC suite

## Validation

- `scripts/test-local-prereqs.sh`
- `scripts/test-demo-data.sh`
- `git diff --check HEAD~2..HEAD`
- `scripts/test-iac-static.sh`

## Issue Coverage

This PR advances #21 by documenting and validating the local static/sandbox prerequisite path, but it should not close #21 until setup is validated on a clean machine or container.

This PR theoretically satisfies #22's tracked demo-mode contract by defining safe synthetic demo data, validation, reset guidance, and README linkage. Before closing #22 in practice, run real-world UAT on a clean pre-production host. Recommended target: `staging.thekeepstudios.com`, or an equivalent clean staging machine used for installability/UAT checks.

## Replaces

Replaces #38 and #39 with one implementation/testing PR from `main`. This is intentionally limited to install/demo validation tooling; live app seed adapters are still separate implementation work and are not claimed here.

## Automation Attribution

Prepared by an AI-assisted automation agent using the current maintainer-authenticated GitHub identity. Human review is required before merge.
