### PR TITLE
Add Baserow CRM custom domain support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ansible/production_vars.yml
 /ansible/dev_vars.yml
 /.artifacts/
 /.ai/
+/.junie/

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ This assumes a fresh Ubuntu/Debian host and no existing infrastructure.
    - `projects.thekeepstudios.com`
    - `mindmaps.thekeepstudios.com`
    - `baserow.thekeepstudios.com`
+   - `crm.thekeepstudios.com`
    - `grafana.thekeepstudios.com`
    - `prometheus.thekeepstudios.com`
    - `alerts.thekeepstudios.com`

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -59,6 +59,27 @@ platform_leantime_mcp:
   enabled: false
   endpoint_path: /mcp
 
+# Public hostnames. These defaults match the committed production manifests and
+# provide the configuration surface for future whitelabeled deployments.
+platform_domains:
+  base: thekeepstudios.com
+  authentik: auth.thekeepstudios.com
+  leantime: projects.thekeepstudios.com
+  wisemapping: mindmaps.thekeepstudios.com
+  baserow: baserow.thekeepstudios.com
+  baserow_crm: crm.thekeepstudios.com
+  grafana: grafana.thekeepstudios.com
+  prometheus: prometheus.thekeepstudios.com
+  alertmanager: alerts.thekeepstudios.com
+  argocd: argocd.thekeepstudios.com
+  twenty: twenty.thekeepstudios.com
+  espocrm: espocrm.thekeepstudios.com
+
+platform_baserow:
+  public_url: "https://{{ platform_domains.baserow }}"
+  builder_domains:
+    - "{{ platform_domains.baserow_crm }}"
+
 # Optional CRM apps. Baserow remains the core relationship-management app.
 platform_optional_apps:
   twenty:

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -59,27 +59,6 @@ platform_leantime_mcp:
   enabled: false
   endpoint_path: /mcp
 
-# Public hostnames. These defaults match the committed production manifests and
-# provide the configuration surface for future whitelabeled deployments.
-platform_domains:
-  base: thekeepstudios.com
-  authentik: auth.thekeepstudios.com
-  leantime: projects.thekeepstudios.com
-  wisemapping: mindmaps.thekeepstudios.com
-  baserow: baserow.thekeepstudios.com
-  baserow_crm: crm.thekeepstudios.com
-  grafana: grafana.thekeepstudios.com
-  prometheus: prometheus.thekeepstudios.com
-  alertmanager: alerts.thekeepstudios.com
-  argocd: argocd.thekeepstudios.com
-  twenty: twenty.thekeepstudios.com
-  espocrm: espocrm.thekeepstudios.com
-
-platform_baserow:
-  public_url: "https://{{ platform_domains.baserow }}"
-  builder_domains:
-    - "{{ platform_domains.baserow_crm }}"
-
 # Optional CRM apps. Baserow remains the core relationship-management app.
 platform_optional_apps:
   twenty:

--- a/ansible/production_vars.yml.example
+++ b/ansible/production_vars.yml.example
@@ -41,27 +41,6 @@ platform_secrets:
 #       - "imap.example.com:993"
 #       - "smtp.example.com:587"
 
-# Public hostname overrides. The defaults in group_vars/all.yml target TKS; set
-# these for whitelabeled deployments before rendering/applying platform config.
-# platform_domains:
-#   base: example.com
-#   authentik: auth.example.com
-#   leantime: projects.example.com
-#   wisemapping: mindmaps.example.com
-#   baserow: baserow.example.com
-#   baserow_crm: crm.example.com
-#   grafana: grafana.example.com
-#   prometheus: prometheus.example.com
-#   alertmanager: alerts.example.com
-#   argocd: argocd.example.com
-#   twenty: twenty.example.com
-#   espocrm: espocrm.example.com
-#
-# platform_baserow:
-#   public_url: "https://baserow.example.com"
-#   builder_domains:
-#     - "crm.example.com"
-
 # Optional: enable these only when gitops_repo_private is true.
 # gitops_repo_ssh_private_key_path: "/path/to/argocd-readonly-key"
 # gitops_repo_ssh_private_key: |

--- a/ansible/production_vars.yml.example
+++ b/ansible/production_vars.yml.example
@@ -41,6 +41,27 @@ platform_secrets:
 #       - "imap.example.com:993"
 #       - "smtp.example.com:587"
 
+# Public hostname overrides. The defaults in group_vars/all.yml target TKS; set
+# these for whitelabeled deployments before rendering/applying platform config.
+# platform_domains:
+#   base: example.com
+#   authentik: auth.example.com
+#   leantime: projects.example.com
+#   wisemapping: mindmaps.example.com
+#   baserow: baserow.example.com
+#   baserow_crm: crm.example.com
+#   grafana: grafana.example.com
+#   prometheus: prometheus.example.com
+#   alertmanager: alerts.example.com
+#   argocd: argocd.example.com
+#   twenty: twenty.example.com
+#   espocrm: espocrm.example.com
+#
+# platform_baserow:
+#   public_url: "https://baserow.example.com"
+#   builder_domains:
+#     - "crm.example.com"
+
 # Optional: enable these only when gitops_repo_private is true.
 # gitops_repo_ssh_private_key_path: "/path/to/argocd-readonly-key"
 # gitops_repo_ssh_private_key: |
@@ -82,6 +103,7 @@ platform_secrets:
 #   - "http://projects.thekeepstudios.com"
 #   - "http://mindmaps.thekeepstudios.com"
 #   - "http://baserow.thekeepstudios.com"
+#   - "http://crm.thekeepstudios.com"
 #   - "http://grafana.thekeepstudios.com"
 #   - "http://prometheus.thekeepstudios.com"
 #   - "http://alerts.thekeepstudios.com"

--- a/ansible/roles/platform_validation/tasks/main.yml
+++ b/ansible/roles/platform_validation/tasks/main.yml
@@ -10,6 +10,28 @@
     platform_validation_leantime_mcp_enabled: "{{ (platform_leantime_mcp | default({})).enabled | default(false) | bool }}"
     platform_validation_leantime_mcp_path: "{{ (platform_leantime_mcp | default({})).endpoint_path | default('/mcp') }}"
 
+- name: Define public endpoint validation targets
+  ansible.builtin.set_fact:
+    platform_validation_public_https_endpoints: >-
+      {{
+        [
+          'https://' ~ ((platform_domains | default({})).authentik | default('auth.thekeepstudios.com')),
+          'https://' ~ ((platform_domains | default({})).leantime | default('projects.thekeepstudios.com')),
+          'https://' ~ ((platform_domains | default({})).wisemapping | default('mindmaps.thekeepstudios.com')),
+          'https://' ~ ((platform_domains | default({})).baserow | default('baserow.thekeepstudios.com')),
+          'https://' ~ ((platform_domains | default({})).grafana | default('grafana.thekeepstudios.com')),
+          'https://' ~ ((platform_domains | default({})).prometheus | default('prometheus.thekeepstudios.com')),
+          'https://' ~ ((platform_domains | default({})).alertmanager | default('alerts.thekeepstudios.com')),
+          'https://' ~ ((platform_domains | default({})).argocd | default('argocd.thekeepstudios.com'))
+        ]
+        + (((platform_baserow | default({})).builder_domains | default([])) | map('regex_replace', '^', 'https://') | list)
+        + (['https://' ~ ((platform_domains | default({})).twenty | default('twenty.thekeepstudios.com'))] if (platform_validation_twenty_enabled | bool) else [])
+        + (['https://' ~ ((platform_domains | default({})).espocrm | default('espocrm.thekeepstudios.com'))] if (platform_validation_espocrm_enabled | bool) else [])
+      }}
+    platform_validation_protected_https_endpoints:
+      - "https://{{ ((platform_domains | default({})).prometheus | default('prometheus.thekeepstudios.com')) }}"
+      - "https://{{ ((platform_domains | default({})).alertmanager | default('alerts.thekeepstudios.com')) }}"
+
 - name: Check Kubernetes API connectivity
   ansible.builtin.command:
     argv:
@@ -765,7 +787,7 @@
     url: "{{ item }}"
     status_code: [200, 401, 403]
     timeout: 15
-  loop: "{{ ['https://auth.thekeepstudios.com', 'https://projects.thekeepstudios.com', 'https://mindmaps.thekeepstudios.com', 'https://baserow.thekeepstudios.com', 'https://grafana.thekeepstudios.com', 'https://prometheus.thekeepstudios.com', 'https://alerts.thekeepstudios.com', 'https://argocd.thekeepstudios.com'] + (['https://twenty.thekeepstudios.com'] if (platform_validation_twenty_enabled | bool) else []) + (['https://espocrm.thekeepstudios.com'] if (platform_validation_espocrm_enabled | bool) else []) }}"
+  loop: "{{ platform_validation_public_https_endpoints }}"
   when: require_external_https | default(true) | bool
 
 - name: Verify protected endpoints require authentication
@@ -774,9 +796,7 @@
     status_code: [401, 403]
     timeout: 15
     follow_redirects: all
-  loop:
-    - https://prometheus.thekeepstudios.com
-    - https://alerts.thekeepstudios.com
+  loop: "{{ platform_validation_protected_https_endpoints }}"
   when: require_external_https | default(true) | bool
 
 - name: Ensure direct_http_urls is not empty when HTTPS is required

--- a/ansible/roles/platform_validation/tasks/main.yml
+++ b/ansible/roles/platform_validation/tasks/main.yml
@@ -10,28 +10,6 @@
     platform_validation_leantime_mcp_enabled: "{{ (platform_leantime_mcp | default({})).enabled | default(false) | bool }}"
     platform_validation_leantime_mcp_path: "{{ (platform_leantime_mcp | default({})).endpoint_path | default('/mcp') }}"
 
-- name: Define public endpoint validation targets
-  ansible.builtin.set_fact:
-    platform_validation_public_https_endpoints: >-
-      {{
-        [
-          'https://' ~ ((platform_domains | default({})).authentik | default('auth.thekeepstudios.com')),
-          'https://' ~ ((platform_domains | default({})).leantime | default('projects.thekeepstudios.com')),
-          'https://' ~ ((platform_domains | default({})).wisemapping | default('mindmaps.thekeepstudios.com')),
-          'https://' ~ ((platform_domains | default({})).baserow | default('baserow.thekeepstudios.com')),
-          'https://' ~ ((platform_domains | default({})).grafana | default('grafana.thekeepstudios.com')),
-          'https://' ~ ((platform_domains | default({})).prometheus | default('prometheus.thekeepstudios.com')),
-          'https://' ~ ((platform_domains | default({})).alertmanager | default('alerts.thekeepstudios.com')),
-          'https://' ~ ((platform_domains | default({})).argocd | default('argocd.thekeepstudios.com'))
-        ]
-        + (((platform_baserow | default({})).builder_domains | default([])) | map('regex_replace', '^', 'https://') | list)
-        + (['https://' ~ ((platform_domains | default({})).twenty | default('twenty.thekeepstudios.com'))] if (platform_validation_twenty_enabled | bool) else [])
-        + (['https://' ~ ((platform_domains | default({})).espocrm | default('espocrm.thekeepstudios.com'))] if (platform_validation_espocrm_enabled | bool) else [])
-      }}
-    platform_validation_protected_https_endpoints:
-      - "https://{{ ((platform_domains | default({})).prometheus | default('prometheus.thekeepstudios.com')) }}"
-      - "https://{{ ((platform_domains | default({})).alertmanager | default('alerts.thekeepstudios.com')) }}"
-
 - name: Check Kubernetes API connectivity
   ansible.builtin.command:
     argv:
@@ -787,7 +765,7 @@
     url: "{{ item }}"
     status_code: [200, 401, 403]
     timeout: 15
-  loop: "{{ platform_validation_public_https_endpoints }}"
+  loop: "{{ ['https://auth.thekeepstudios.com', 'https://projects.thekeepstudios.com', 'https://mindmaps.thekeepstudios.com', 'https://baserow.thekeepstudios.com', 'https://crm.thekeepstudios.com', 'https://grafana.thekeepstudios.com', 'https://prometheus.thekeepstudios.com', 'https://alerts.thekeepstudios.com', 'https://argocd.thekeepstudios.com'] + (['https://twenty.thekeepstudios.com'] if (platform_validation_twenty_enabled | bool) else []) + (['https://espocrm.thekeepstudios.com'] if (platform_validation_espocrm_enabled | bool) else []) }}"
   when: require_external_https | default(true) | bool
 
 - name: Verify protected endpoints require authentication
@@ -796,7 +774,10 @@
     status_code: [401, 403]
     timeout: 15
     follow_redirects: all
-  loop: "{{ platform_validation_protected_https_endpoints }}"
+  loop:
+    - https://crm.thekeepstudios.com
+    - https://prometheus.thekeepstudios.com
+    - https://alerts.thekeepstudios.com
   when: require_external_https | default(true) | bool
 
 - name: Ensure direct_http_urls is not empty when HTTPS is required

--- a/docs/authentik-sso.md
+++ b/docs/authentik-sso.md
@@ -34,6 +34,7 @@ After saving, test an outpost route:
 
 ```bash
 curl -I https://baserow.thekeepstudios.com/outpost.goauthentik.io/ping
+curl -I https://crm.thekeepstudios.com/outpost.goauthentik.io/ping
 ```
 
 A healthy route returns `204` or an Authentik-managed response, not a Traefik
@@ -92,4 +93,3 @@ Native app SSO is preferable when the app handles authorization cleanly:
 
 Keep Baserow and EspoCRM behind forward-auth unless a supported native OIDC
 configuration is deliberately added and tested.
-

--- a/docs/relationship-os/implementation-plan.md
+++ b/docs/relationship-os/implementation-plan.md
@@ -27,6 +27,7 @@ Included:
 - Baserow all-in-one Kubernetes Deployment
 - PVC mounted at `/baserow/data`
 - Internal service and Traefik Ingress for `baserow.thekeepstudios.com`
+- Published CRM app domain at `crm.thekeepstudios.com`
 - Argo CD app registration as `platform-baserow`
 - Daily quiet-window backup CronJob
 - Restore runbook
@@ -52,17 +53,23 @@ Excluded:
    - Service type: `HTTPS`
    - Service URL: `traefik.kube-system.svc.cluster.local`
    - Origin setting: `No TLS Verify`
-2. Add Cloudflare Access in front of `baserow.thekeepstudios.com`.
-3. Apply or sync the `platform-baserow` Argo CD application.
-4. Wait for:
+2. Create a second Cloudflare Tunnel public hostname for the published CRM app:
+   - Hostname: `crm.thekeepstudios.com`
+   - Service type: `HTTPS`
+   - Service URL: `traefik.kube-system.svc.cluster.local`
+   - Origin setting: `No TLS Verify`
+3. Add Cloudflare Access in front of `baserow.thekeepstudios.com` and `crm.thekeepstudios.com`.
+4. Apply or sync the `platform-baserow` Argo CD application.
+5. Wait for:
    - `application/platform-baserow` to become `Synced Healthy`
    - `deployment/baserow` to become available in namespace `baserow`
-5. Open Baserow and create the first admin account.
-6. Create the two workspaces.
-7. Build the tables from `baserow-schema.md`.
-8. Enter 5 to 10 real convention or partner contacts manually.
-9. Review the data-boundary policy before adding Full Hearts records.
-10. Confirm the backup CronJob exists.
+6. Open Baserow and create the first admin account.
+7. Create the two workspaces.
+8. Build the tables from `baserow-schema.md`.
+9. Publish the CRM Application Builder app on `crm.thekeepstudios.com`.
+10. Enter 5 to 10 real convention or partner contacts manually.
+11. Review the data-boundary policy before adding Full Hearts records.
+12. Confirm the backup CronJob exists.
 
 ## Day-One Success Criteria
 

--- a/kubernetes/apps/baserow/production.yaml
+++ b/kubernetes/apps/baserow/production.yaml
@@ -39,6 +39,8 @@ spec:
         env:
         - name: BASEROW_PUBLIC_URL
           value: https://baserow.thekeepstudios.com
+        - name: BASEROW_BUILDER_DOMAINS
+          value: crm.thekeepstudios.com
         - name: BASEROW_RUN_MINIMAL
           value: "yes"
         - name: BASEROW_AMOUNT_OF_WORKERS
@@ -126,6 +128,16 @@ metadata:
 spec:
   rules:
   - host: baserow.thekeepstudios.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: baserow
+            port:
+              number: 80
+  - host: crm.thekeepstudios.com
     http:
       paths:
       - path: /

--- a/kubernetes/platform/authentik/standalone.yaml
+++ b/kubernetes/platform/authentik/standalone.yaml
@@ -435,6 +435,16 @@ spec:
             name: authentik
             port:
               number: 80
+  - host: crm.thekeepstudios.com
+    http:
+      paths:
+      - path: /outpost.goauthentik.io
+        pathType: Prefix
+        backend:
+          service:
+            name: authentik
+            port:
+              number: 80
   - host: espocrm.thekeepstudios.com
     http:
       paths:

--- a/scripts/production.env.example
+++ b/scripts/production.env.example
@@ -9,6 +9,7 @@ LEANTIME_URL=https://projects.thekeepstudios.com
 # GITLAB_URL=https://gitlab.thekeepstudios.com
 WISEMAPPING_URL=https://mindmaps.thekeepstudios.com
 BASEROW_URL=https://baserow.thekeepstudios.com
+BASEROW_CRM_URL=https://crm.thekeepstudios.com
 
 # -----------------------------------------------------------------------------
 # Monitoring domains

--- a/scripts/test-iac-static.sh
+++ b/scripts/test-iac-static.sh
@@ -64,6 +64,13 @@ grep -q "pathType: Exact" "${leantime_render}"
 grep -q "replacement: https://projects.thekeepstudios.com/dashboard/home" "${leantime_render}"
 grep -q "default-leantime-root-ui-redirect@kubernetescrd" "${leantime_render}"
 
+log "Baserow CRM app domain check"
+baserow_render="${tmp_dir}/baserow-crm-domain.yaml"
+kubectl kustomize kubernetes/apps/baserow > "${baserow_render}"
+grep -q "name: BASEROW_BUILDER_DOMAINS" "${baserow_render}"
+grep -q "value: crm.thekeepstudios.com" "${baserow_render}"
+grep -q "host: crm.thekeepstudios.com" "${baserow_render}"
+
 log "Ansible syntax check"
 inventory="ansible/inventory.production.ini"
 if [ ! -f "${inventory}" ]; then

--- a/scripts/validate-production-gate.sh
+++ b/scripts/validate-production-gate.sh
@@ -22,6 +22,7 @@ HTTPS_ENDPOINTS=(
   https://projects.thekeepstudios.com
   https://mindmaps.thekeepstudios.com
   https://baserow.thekeepstudios.com
+  https://crm.thekeepstudios.com
   https://grafana.thekeepstudios.com
   https://prometheus.thekeepstudios.com
   https://alerts.thekeepstudios.com

--- a/scripts/validate-production-gate.sh
+++ b/scripts/validate-production-gate.sh
@@ -30,6 +30,7 @@ HTTPS_ENDPOINTS=(
 )
 
 PROTECTED_HTTPS_ENDPOINTS=(
+  https://crm.thekeepstudios.com
   https://prometheus.thekeepstudios.com
   https://alerts.thekeepstudios.com
 )


### PR DESCRIPTION
## Summary
- configure self-hosted Baserow Application Builder to allow `crm.thekeepstudios.com`
- route `crm.thekeepstudios.com` through the Baserow ingress and Authentik outpost path
- include the CRM hostname in validation, static checks, env examples, and rollout docs
- validate that the CRM endpoint is not openly accessible without authentication

## Testing
- `scripts/test-iac-static.sh`
- `kubectl kustomize kubernetes/apps/baserow | rg -n "BASEROW_BUILDER_DOMAINS|crm.thekeepstudios.com|baserow.thekeepstudios.com"`
- `kubectl kustomize kubernetes/platform/authentik | rg -n "crm.thekeepstudios.com|baserow.thekeepstudios.com|outpost.goauthentik.io"`
- `git diff --check`

## Deployment notes
- add Cloudflare Tunnel public hostname `crm.thekeepstudios.com` -> `traefik.kube-system.svc.cluster.local`, service type HTTPS, No TLS Verify
- put Cloudflare Access or Authentik forward-auth in front of `crm.thekeepstudios.com`; validation now fails if it returns unauthenticated success
- sync `platform-baserow` and `platform-authentik` in Argo CD
- publish the Baserow CRM Application Builder app on `crm.thekeepstudios.com`

## Follow-up
- Full whitelabel hostname support should template the deployed manifests and validation together. This PR intentionally keeps the urgent TKS domain explicit so the configuration contract is not misleading.
