### PR TITLE
Add baseline quality check runner

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,60 @@
+name: Quality Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/quality.yml"
+      - ".gitignore"
+      - "**/*.md"
+      - "**/*.sh"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - "README.md"
+      - "ansible.cfg"
+      - "ansible/**"
+      - "kubernetes/**"
+      - "scripts/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/quality.yml"
+      - ".gitignore"
+      - "**/*.md"
+      - "**/*.sh"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - "README.md"
+      - "ansible.cfg"
+      - "ansible/**"
+      - "kubernetes/**"
+      - "scripts/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Ansible
+        run: python -m pip install ansible-core==2.16.3
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.33.0
+
+      - name: Run quality checks
+        run: scripts/test-quality.sh

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ ansible/production_vars.yml
 /ansible/dev_vars.yml
 /.artifacts/
 /.ai/
+/.junie/
+__pycache__/
+.venv/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -153,16 +153,64 @@ Target for full production:
 - Human and AI contributors should challenge requests when the proposed implementation does not match the actual goal or creates avoidable operational burden.
 - Prefer reviewable files, dry runs, and copy/paste commands over hidden automation for one-time operations.
 
+### TODO Tracking Standard
+
+Use GitHub as the durable TODO system. Do not rely on private chat memory, local notes, unchecked code comments, or stale PR prose for work that must survive a handoff.
+
+Every non-trivial TODO must be represented in one of these forms:
+
+- GitHub issue: durable backlog item, follow-up, blocker, or acceptance criterion not finished by the current PR.
+- PR TODO ledger comment: short-lived checklist for the PR's remaining review, validation, and merge-readiness work.
+- Issue TODO ledger comment: current decomposition of a larger issue into ordered, owner-visible next actions.
+- Inline code TODO: allowed only when it points to a GitHub issue number and describes a concrete code-local follow-up.
+
+Use this format for TODO ledger comments:
+
+```markdown
+## TODO Ledger
+
+- [ ] Owner: <human|agent|PM> | Type: <blocker|follow-up|validation|decision> | Ref: #<issue-or-pr> | Due: <before-merge|next-sprint|later>
+      Action: <one concrete next action>
+      Evidence: <command, review, PR, issue, or production proof that will close it>
+```
+
+Rules:
+
+- A PR may use `Closes #...` only when its merged diff satisfies every acceptance criterion for that issue.
+- If a PR is useful but partial, use `Refs #...` and add or link follow-up issues before marking the PR ready for review.
+- Broad issues should keep one current TODO ledger comment. Update that comment instead of scattering status across several comments.
+- Human-driven tasks must be labeled as human-owned in the ledger; agents should not silently convert them into code changes.
+- Before ending a work session, update the relevant PR or issue ledger with what remains, who owns it, and what evidence is needed next.
+
 ### Before Merging
 
 For infrastructure changes, confirm the relevant items before merging:
 
+- Repository quality checks pass with `scripts/test-quality.sh`.
 - Static checks pass, such as `scripts/test-iac-static.sh` when it applies.
 - Ansible syntax or playbook checks were run for changed playbooks and roles.
 - Local k3d smoke or observation checks were run for app changes when practical.
 - GitOps manifests do not accidentally target a feature branch unless that is intentional for testing.
 - No secrets, tokens, passwords, kubeconfigs, or private keys are committed.
 - Rollout, validation, and rollback steps are clear enough for another engineer to follow.
+
+### Quality Checks
+
+Run the repo-level quality gate before opening or updating infrastructure PRs:
+
+```bash
+scripts/test-quality.sh
+```
+
+The current tracked surfaces are shell scripts, Ansible playbooks and roles, Kubernetes YAML, docs, and this GitHub Actions workflow. There are no tracked Python services or container build files on `main` yet, so those checks stay deferred until those surfaces exist on the branch being reviewed.
+
+The first enforced baseline reuses `scripts/test-iac-static.sh`, which already covers Git whitespace, shell syntax, Kustomize rendering, Ansible syntax, and focused EspoCRM validation. Optional stricter tools are wired behind `QUALITY_STRICT=true` and run only when installed:
+
+```bash
+QUALITY_STRICT=true scripts/test-quality.sh
+```
+
+Use the strict mode to evaluate `shellcheck`, `shfmt`, `actionlint`, `yamllint`, `ruff`, and `hadolint` without turning noisy or branch-specific tools into a default PR blocker too early.
 
 ## Operations Runbook
 
@@ -527,6 +575,7 @@ This is the backlog for moving from production-like to high availability:
 - Cloudflare Tunnel edge deployment: `kubernetes/platform/cloudflared/*`
 - GitOps apps/root: `kubernetes/gitops/*`
 - Leantime backup CronJob: `kubernetes/apps/leantime/backup-cronjob.yaml`
+- Repository quality gate: `scripts/test-quality.sh`
 - Leantime UI/MCP route contract: `docs/leantime-mcp-routing.md`
 - Leantime UI/MCP route probe: `scripts/check-leantime-routing.sh`
 - Runtime env template: `scripts/production.env.example`

--- a/scripts/test-quality.sh
+++ b/scripts/test-quality.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "${SCRIPT_DIR}")"
+QUALITY_STRICT="${QUALITY_STRICT:-false}"
+cd "${PROJECT_ROOT}"
+export ANSIBLE_STDOUT_CALLBACK="${ANSIBLE_STDOUT_CALLBACK:-default}"
+
+log() {
+  printf '\n== %s ==\n' "$*"
+}
+
+repo_files() {
+  git ls-files --cached --others --exclude-standard -- "$@" | sort -u
+}
+
+count_repo_files() {
+  repo_files "$@" | wc -l | tr -d '[:space:]'
+}
+
+command_available() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+run_optional_linters() {
+  if [ "${QUALITY_STRICT}" != "true" ]; then
+    echo "skip optional linters: set QUALITY_STRICT=true to run installed strict tools"
+    return
+  fi
+
+  local shell_files=()
+  mapfile -t shell_files < <(repo_files '*.sh')
+  if [ "${#shell_files[@]}" -gt 0 ]; then
+    if command_available shellcheck; then
+      shellcheck "${shell_files[@]}"
+    else
+      echo "skip shellcheck: not installed"
+    fi
+
+    if command_available shfmt; then
+      shfmt -d "${shell_files[@]}"
+    else
+      echo "skip shfmt: not installed"
+    fi
+  fi
+
+  local workflow_files=()
+  mapfile -t workflow_files < <(repo_files '.github/workflows/*.yml' '.github/workflows/*.yaml')
+  if [ "${#workflow_files[@]}" -gt 0 ]; then
+    if command_available actionlint; then
+      actionlint "${workflow_files[@]}"
+    else
+      echo "skip actionlint: not installed"
+    fi
+  fi
+
+  local yaml_files=()
+  mapfile -t yaml_files < <(repo_files '*.yml' '*.yaml')
+  if [ "${#yaml_files[@]}" -gt 0 ]; then
+    if command_available yamllint; then
+      yamllint "${yaml_files[@]}"
+    else
+      echo "skip yamllint: not installed"
+    fi
+  fi
+
+  local python_files=()
+  mapfile -t python_files < <(repo_files '*.py')
+  if [ "${#python_files[@]}" -gt 0 ]; then
+    if command_available ruff; then
+      ruff check "${python_files[@]}"
+    else
+      echo "skip ruff: not installed"
+    fi
+  fi
+
+  local container_files=()
+  mapfile -t container_files < <(repo_files 'Dockerfile' '**/Dockerfile' '*.Dockerfile' '*Dockerfile')
+  if [ "${#container_files[@]}" -gt 0 ]; then
+    if command_available hadolint; then
+      hadolint "${container_files[@]}"
+    else
+      echo "skip hadolint: not installed"
+    fi
+  fi
+}
+
+log "Quality inventory"
+printf 'shell_scripts=%s\n' "$(count_repo_files '*.sh')"
+printf 'yaml_files=%s\n' "$(count_repo_files '*.yml' '*.yaml')"
+printf 'ansible_files=%s\n' "$(count_repo_files 'ansible/**')"
+printf 'kubernetes_files=%s\n' "$(count_repo_files 'kubernetes/**')"
+printf 'python_files=%s\n' "$(count_repo_files '*.py')"
+printf 'container_build_files=%s\n' "$(count_repo_files 'Dockerfile' '**/Dockerfile' '*.Dockerfile' '*Dockerfile')"
+printf 'github_workflows=%s\n' "$(count_repo_files '.github/workflows/*.yml' '.github/workflows/*.yaml')"
+printf 'markdown_files=%s\n' "$(count_repo_files '*.md')"
+
+log "Baseline static checks"
+"${SCRIPT_DIR}/test-iac-static.sh"
+
+log "Optional traditional linters"
+run_optional_linters
+
+log "Quality checks passed"


### PR DESCRIPTION
## Summary

- add `scripts/test-quality.sh` as the repo-level quality inventory and baseline runner
- add a `Quality Checks` GitHub Actions workflow that runs the same command on PRs and `main`
- document the current repo surfaces and the opt-in strict lint path
- document the GitHub TODO Ledger standard for durable handoffs

## Notes

Refs #57, but does not close it yet.

This is the first low-noise slice: it reuses the existing static IaC checks as the enforced baseline. Optional stricter tools are wired behind `QUALITY_STRICT=true` so they can be evaluated without turning noisy or branch-specific checks into default PR blockers too early.

Current `main` has no tracked Python services or container build files, so those checks stay deferred until those surfaces exist on the branch being reviewed.

The deferred #57 work is now tracked in follow-up issues:

- #59 for strict linter promotion
- #60 for secret scanning
- #61 for service-surface checks

Related #56 follow-up issues created while applying the TODO standard:

- #62 for the repeatable app-support contract
- #63 for dev smoke/observe metadata consolidation

## Validation

- `bash -n scripts/test-quality.sh && bash -n scripts/test-iac-static.sh`
- `git diff --check`
- `scripts/test-quality.sh`
- `QUALITY_STRICT=true scripts/test-quality.sh` (strict tools are not installed locally, so this verified skip behavior)
- GitHub Actions `Quality` passed on head `9a7eed9`