### PR TITLE
Consolidate dev app target metadata

### DIFF
--- a/scripts/dev-app-targets.sh
+++ b/scripts/dev-app-targets.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+DEV_APP_TARGET_USAGE="wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform"
+
+dev_app_print_usage() {
+  local script_name="$1"
+  local suffix="${2:-}"
+
+  echo "Usage: ${script_name} [${DEV_APP_TARGET_USAGE}]${suffix}" >&2
+}
+
+dev_app_is_target() {
+  case "$1" in
+    wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+dev_app_expand_target() {
+  case "$1" in
+    platform)
+      printf '%s\n' wisemapping leantime baserow
+      ;;
+    optional-crm|crm-bakeoff)
+      printf '%s\n' twenty espocrm
+      ;;
+    wisemapping|leantime|baserow|twenty|espocrm)
+      printf '%s\n' "$1"
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+}
+
+dev_app_observe_config() {
+  local target="$1"
+
+  case "${target}" in
+    wisemapping)
+      APP_NAMESPACE="wisemapping"
+      APP_SERVICE="wisemapping"
+      APP_DEPLOYMENT="wisemapping"
+      APP_PORT="${WISEMAPPING_OBSERVE_PORT:-18081}"
+      APP_HOST="${WISEMAPPING_PROBE_HOST:-mindmaps.thekeepstudios.com}"
+      APP_PROBE_PATH="/api/restful/app/config"
+      APP_PROBE_PATTERN="apiBaseUrl|uiBaseUrl"
+      APP_CONFIG_KIND="wisemapping"
+      ;;
+    leantime)
+      APP_NAMESPACE="default"
+      APP_SERVICE="leantime"
+      APP_DEPLOYMENT="leantime"
+      APP_PORT="${LEANTIME_OBSERVE_PORT:-18080}"
+      APP_HOST="${LEANTIME_PROBE_HOST:-projects.thekeepstudios.com}"
+      APP_PROBE_PATH="/auth/login"
+      APP_PROBE_PATTERN="leantime|login|email|password|install|redirecting"
+      APP_CONFIG_KIND="leantime"
+      ;;
+    baserow)
+      APP_NAMESPACE="baserow"
+      APP_SERVICE="baserow"
+      APP_DEPLOYMENT="baserow"
+      APP_PORT="${BASEROW_OBSERVE_PORT:-18082}"
+      APP_HOST="${BASEROW_PROBE_HOST:-baserow.thekeepstudios.com}"
+      APP_PROBE_PATH="/"
+      APP_PROBE_PATTERN="login|sign|create account"
+      APP_CONFIG_KIND="baserow"
+      ;;
+    twenty)
+      APP_NAMESPACE="twenty"
+      APP_SERVICE="twenty"
+      APP_DEPLOYMENT="twenty-server"
+      APP_PORT="${TWENTY_OBSERVE_PORT:-18083}"
+      APP_HOST="${TWENTY_PROBE_HOST:-twenty.thekeepstudios.com}"
+      APP_PROBE_PATH="/"
+      APP_PROBE_PATTERN="twenty|login|sign|workspace"
+      APP_CONFIG_KIND="twenty"
+      ;;
+    espocrm)
+      APP_NAMESPACE="espocrm"
+      APP_SERVICE="espocrm"
+      APP_DEPLOYMENT="espocrm"
+      APP_PORT="${ESPOCRM_OBSERVE_PORT:-18084}"
+      APP_HOST="${ESPOCRM_PROBE_HOST:-espocrm.thekeepstudios.com}"
+      APP_PROBE_PATH="/"
+      APP_PROBE_PATTERN="espocrm|login|username|password"
+      APP_CONFIG_KIND="espocrm"
+      ;;
+    *)
+      echo "Unknown concrete dev app target: ${target}" >&2
+      return 2
+      ;;
+  esac
+}

--- a/scripts/dev-observe.sh
+++ b/scripts/dev-observe.sh
@@ -7,6 +7,8 @@ cd "${PROJECT_ROOT}"
 
 # shellcheck source=scripts/dev-preflight.sh
 source "${SCRIPT_DIR}/dev-preflight.sh"
+# shellcheck source=scripts/dev-app-targets.sh
+source "${SCRIPT_DIR}/dev-app-targets.sh"
 
 CLUSTER_NAME="${K3D_CLUSTER_NAME:-thekeep-dev}"
 OPEN_BROWSER="${DEV_OBSERVE_OPEN:-true}"
@@ -55,68 +57,6 @@ ensure_context() {
   fi
 
   dev_preflight_check_kubernetes_node_pressure
-}
-
-app_config() {
-  local target="$1"
-
-  case "${target}" in
-    wisemapping)
-      APP_NAMESPACE="wisemapping"
-      APP_SERVICE="wisemapping"
-      APP_DEPLOYMENT="wisemapping"
-      APP_PORT="${WISEMAPPING_OBSERVE_PORT:-18081}"
-      APP_HOST="${WISEMAPPING_PROBE_HOST:-mindmaps.thekeepstudios.com}"
-      APP_PROBE_PATH="/api/restful/app/config"
-      APP_PROBE_PATTERN="apiBaseUrl|uiBaseUrl"
-      APP_CONFIG_KIND="wisemapping"
-      ;;
-    leantime)
-      APP_NAMESPACE="default"
-      APP_SERVICE="leantime"
-      APP_DEPLOYMENT="leantime"
-      APP_PORT="${LEANTIME_OBSERVE_PORT:-18080}"
-      APP_HOST="${LEANTIME_PROBE_HOST:-projects.thekeepstudios.com}"
-      APP_PROBE_PATH="/auth/login"
-      APP_PROBE_PATTERN="leantime|login|email|password|install|redirecting"
-      APP_CONFIG_KIND="leantime"
-      ;;
-    baserow)
-      APP_NAMESPACE="baserow"
-      APP_SERVICE="baserow"
-      APP_DEPLOYMENT="baserow"
-      APP_PORT="${BASEROW_OBSERVE_PORT:-18082}"
-      APP_HOST="${BASEROW_PROBE_HOST:-baserow.thekeepstudios.com}"
-      APP_PROBE_PATH="/"
-      APP_PROBE_PATTERN="login|sign|create account"
-      APP_CONFIG_KIND="baserow"
-      ;;
-    twenty)
-      APP_NAMESPACE="twenty"
-      APP_SERVICE="twenty"
-      APP_DEPLOYMENT="twenty-server"
-      APP_PORT="${TWENTY_OBSERVE_PORT:-18083}"
-      APP_HOST="${TWENTY_PROBE_HOST:-twenty.thekeepstudios.com}"
-      APP_PROBE_PATH="/"
-      APP_PROBE_PATTERN="twenty|login|sign|workspace"
-      APP_CONFIG_KIND="twenty"
-      ;;
-    espocrm)
-      APP_NAMESPACE="espocrm"
-      APP_SERVICE="espocrm"
-      APP_DEPLOYMENT="espocrm"
-      APP_PORT="${ESPOCRM_OBSERVE_PORT:-18084}"
-      APP_HOST="${ESPOCRM_PROBE_HOST:-espocrm.thekeepstudios.com}"
-      APP_PROBE_PATH="/"
-      APP_PROBE_PATTERN="espocrm|login|username|password"
-      APP_CONFIG_KIND="espocrm"
-      ;;
-    *)
-      echo "Unknown dev observe target: ${target}" >&2
-      echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform]" >&2
-      return 2
-      ;;
-  esac
 }
 
 patch_local_config() {
@@ -281,7 +221,7 @@ observe_one() {
   local human_url
   local browser_bin
 
-  app_config "${target}"
+  dev_app_observe_config "${target}"
   mkdir -p "${artifact_dir}"
 
   kubectl get service "${APP_SERVICE}" -n "${APP_NAMESPACE}" >/dev/null
@@ -344,48 +284,27 @@ EOF
 main() {
   local targets=("$@")
   local target
+  local concrete_target
 
   if [ "${#targets[@]}" -eq 0 ]; then
     targets=(platform)
   fi
 
   for target in "${targets[@]}"; do
-    case "${target}" in
-      platform|wisemapping|leantime|baserow)
-        ;;
-      twenty|espocrm|optional-crm|crm-bakeoff)
-        ;;
-      *)
-        echo "Unknown dev observe target: ${target}" >&2
-        echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform]" >&2
-        exit 2
-        ;;
-    esac
+    if ! dev_app_is_target "${target}"; then
+      echo "Unknown dev observe target: ${target}" >&2
+      dev_app_print_usage "scripts/dev-observe.sh"
+      exit 2
+    fi
   done
 
   ensure_context
   trap cleanup EXIT INT TERM
 
   for target in "${targets[@]}"; do
-    case "${target}" in
-      platform)
-        observe_one wisemapping
-        observe_one leantime
-        observe_one baserow
-        ;;
-      optional-crm|crm-bakeoff)
-        observe_one twenty
-        observe_one espocrm
-        ;;
-      wisemapping|leantime|baserow|twenty|espocrm)
-        observe_one "${target}"
-        ;;
-      *)
-        echo "Unknown dev observe target: ${target}" >&2
-        echo "Usage: scripts/dev-observe.sh [wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform]" >&2
-        exit 2
-        ;;
-    esac
+    while IFS= read -r concrete_target; do
+      observe_one "${concrete_target}"
+    done < <(dev_app_expand_target "${target}")
   done
 
   echo ""

--- a/scripts/dev-smoke.sh
+++ b/scripts/dev-smoke.sh
@@ -7,6 +7,8 @@ cd "${PROJECT_ROOT}"
 
 # shellcheck source=scripts/dev-preflight.sh
 source "${SCRIPT_DIR}/dev-preflight.sh"
+# shellcheck source=scripts/dev-app-targets.sh
+source "${SCRIPT_DIR}/dev-app-targets.sh"
 
 CLUSTER_NAME="${K3D_CLUSTER_NAME:-thekeep-dev}"
 PROBE_IMAGE="${DEV_PROBE_IMAGE:-curlimages/curl:8.8.0}"
@@ -329,6 +331,7 @@ smoke_espocrm() {
 
 run_target() {
   local target="$1"
+  local concrete_target
 
   case "${target}" in
     wisemapping)
@@ -362,32 +365,29 @@ run_target() {
       fi
       ;;
     optional-crm|crm-bakeoff)
-      run_target twenty
-      run_target espocrm
+      while IFS= read -r concrete_target; do
+        run_target "${concrete_target}"
+      done < <(dev_app_expand_target "${target}")
       ;;
     platform)
-      run_target wisemapping
-      run_target leantime
-      run_target baserow
+      while IFS= read -r concrete_target; do
+        run_target "${concrete_target}"
+      done < <(dev_app_expand_target "${target}")
       ;;
     *)
       echo "Unknown dev smoke target: ${target}" >&2
-      echo "Usage: scripts/dev-smoke.sh [wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform]..." >&2
+      dev_app_print_usage "scripts/dev-smoke.sh" "..."
       return 2
       ;;
   esac
 }
 
 validate_target() {
-  case "$1" in
-    wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform)
-      ;;
-    *)
-      echo "Unknown dev smoke target: $1" >&2
-      echo "Usage: scripts/dev-smoke.sh [wisemapping|leantime|baserow|twenty|espocrm|optional-crm|crm-bakeoff|platform]..." >&2
-      return 2
-      ;;
-  esac
+  if ! dev_app_is_target "$1"; then
+    echo "Unknown dev smoke target: $1" >&2
+    dev_app_print_usage "scripts/dev-smoke.sh" "..."
+    return 2
+  fi
 }
 
 main() {


### PR DESCRIPTION
## Summary

- add `scripts/dev-app-targets.sh` for shared dev app target metadata
- reuse the shared target list, usage text, and target expansion in `scripts/dev-smoke.sh`
- reuse the shared target list, usage text, target expansion, and observe metadata in `scripts/dev-observe.sh`

## Notes

Closes #63.

This preserves the existing wrapper entrypoints such as `scripts/dev-baserow-smoke.sh` and `scripts/dev-baserow-observe.sh`. The behavior change is intended to be structural only: target validation and composite target expansion now live in one helper instead of being repeated in both scripts.

I did not run live smoke or observe commands for valid targets because those can create or mutate a dev k3d cluster and, for observe, open or capture browser artifacts.

## Validation

- `bash -n scripts/dev-app-targets.sh scripts/dev-smoke.sh scripts/dev-observe.sh`
- `git diff --check`
- `source scripts/dev-app-targets.sh; dev_app_expand_target ...`
- `scripts/dev-smoke.sh not-a-target` returns `exit=2` with usage
- `scripts/dev-observe.sh not-a-target` returns `exit=2` with usage
- `scripts/test-iac-static.sh`
