### PR TITLE
Add EspoCRM assistant GitOps integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ This is the backlog for moving from production-like to high availability:
 - Cloudflare Tunnel edge deployment: `kubernetes/platform/cloudflared/*`
 - GitOps apps/root: `kubernetes/gitops/*`
 - App support contract: `docs/app-support-contract.md`
+- Optional CRM and EspoCRM assistant operator config: `docs/optional-crm-apps.md`
 - Leantime backup CronJob: `kubernetes/apps/leantime/backup-cronjob.yaml`
 - Repository quality gate: `scripts/test-quality.sh`
 - Leantime UI/MCP route contract: `docs/leantime-mcp-routing.md`

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -65,6 +65,8 @@ platform_optional_apps:
     enabled: false
   espocrm:
     enabled: false
+  espocrm_assistant:
+    enabled: false
 
 platform_validation_argo_app_status_retries: 60
 platform_validation_argo_app_status_delay: 10

--- a/ansible/production_vars.yml.example
+++ b/ansible/production_vars.yml.example
@@ -27,6 +27,19 @@ platform_secrets:
   espocrm_db_root_password: "CHANGE_ME"
   espocrm_db_password: "CHANGE_ME"
   espocrm_admin_password: "CHANGE_ME"
+  # EspoCRM assistant requires platform_optional_apps.espocrm.enabled: true.
+  # Use a least-privilege read API user for assistant-visible MCP tools.
+  espocrm_assistant_read_api_key: "CHANGE_ME"
+  # Optional HMAC secret for the read API user, if enabled in EspoCRM.
+  espocrm_assistant_read_secret_key: ""
+  # Use a separate write API user for the approval/apply endpoint only.
+  espocrm_assistant_write_api_key: "CHANGE_ME"
+  # Optional HMAC secret for the write API user, if enabled in EspoCRM.
+  espocrm_assistant_write_secret_key: ""
+  # Protects internal non-mutating JSON helper routes.
+  espocrm_assistant_token: "CHANGE_ME"
+  # Protects /approval/apply-change; share only with the approved executor path.
+  espocrm_assistant_apply_token: "CHANGE_ME"
 
 # Optional CRM app toggles. Baserow remains the core relationship-management app.
 # platform_optional_apps:
@@ -40,6 +53,9 @@ platform_secrets:
 #     email_server_allowed_address_list:
 #       - "imap.example.com:993"
 #       - "smtp.example.com:587"
+#   espocrm_assistant:
+#     # Requires espocrm.enabled: true. The assistant does not enable EspoCRM.
+#     enabled: false
 
 # Optional: enable these only when gitops_repo_private is true.
 # gitops_repo_ssh_private_key_path: "/path/to/argocd-readonly-key"

--- a/ansible/roles/platform_gitops/tasks/main.yml
+++ b/ansible/roles/platform_gitops/tasks/main.yml
@@ -426,6 +426,40 @@
   no_log: true
   when: ((platform_optional_apps | default({})).espocrm | default({})).enabled | default(false) | bool
 
+- name: Apply EspoCRM assistant optional app secret
+  ansible.builtin.command:
+    argv:
+      - "{{ platform_kubectl }}"
+      - apply
+      - -f
+      - "-"
+  args:
+    stdin: >-
+      {{
+        {
+          'apiVersion': 'v1',
+          'kind': 'Secret',
+          'metadata': {
+            'name': 'espocrm-assistant-secrets',
+            'namespace': 'espocrm'
+          },
+          'type': 'Opaque',
+          'stringData': {
+            'ESPOCRM_READ_API_KEY': platform_secrets.espocrm_assistant_read_api_key | default(''),
+            'ESPOCRM_READ_SECRET_KEY': platform_secrets.espocrm_assistant_read_secret_key | default(''),
+            'ESPOCRM_WRITE_API_KEY': platform_secrets.espocrm_assistant_write_api_key | default(''),
+            'ESPOCRM_WRITE_SECRET_KEY': platform_secrets.espocrm_assistant_write_secret_key | default(''),
+            'ESPOCRM_ASSISTANT_TOKEN': platform_secrets.espocrm_assistant_token | default(''),
+            'ESPOCRM_ASSISTANT_APPLY_TOKEN': platform_secrets.espocrm_assistant_apply_token | default('')
+          }
+        } | to_nice_yaml
+      }}
+  become: true
+  become_user: k3s-admin
+  environment: "{{ platform_kubectl_env }}"
+  no_log: true
+  when: ((platform_optional_apps | default({})).espocrm_assistant | default({})).enabled | default(false) | bool
+
 - name: Apply Grafana admin secret
   ansible.builtin.command:
     argv:

--- a/ansible/setup_k3s_production.yml
+++ b/ansible/setup_k3s_production.yml
@@ -94,6 +94,15 @@
       ansible.builtin.set_fact:
         platform_optional_twenty_enabled: "{{ ((platform_optional_apps | default({})).twenty | default({})).enabled | default(false) | bool }}"
         platform_optional_espocrm_enabled: "{{ ((platform_optional_apps | default({})).espocrm | default({})).enabled | default(false) | bool }}"
+        platform_optional_espocrm_assistant_enabled: "{{ ((platform_optional_apps | default({})).espocrm_assistant | default({})).enabled | default(false) | bool }}"
+      tags: [always]
+
+    - name: Fail if EspoCRM assistant is enabled without EspoCRM
+      ansible.builtin.fail:
+        msg: "platform_optional_apps.espocrm_assistant.enabled requires platform_optional_apps.espocrm.enabled."
+      when:
+        - platform_optional_espocrm_assistant_enabled | bool
+        - not (platform_optional_espocrm_enabled | bool)
       tags: [always]
 
     - name: Validate EspoCRM email configuration
@@ -107,7 +116,13 @@
         required_optional_crm_secret_keys: >-
           {{
             (['twenty_pg_database_password', 'twenty_encryption_key', 'twenty_app_secret'] if (platform_optional_twenty_enabled | bool) else []) +
-            (['espocrm_db_root_password', 'espocrm_db_password', 'espocrm_admin_password'] if (platform_optional_espocrm_enabled | bool) else [])
+            (['espocrm_db_root_password', 'espocrm_db_password', 'espocrm_admin_password'] if (platform_optional_espocrm_enabled | bool) else []) +
+            ([
+              'espocrm_assistant_read_api_key',
+              'espocrm_assistant_write_api_key',
+              'espocrm_assistant_token',
+              'espocrm_assistant_apply_token'
+            ] if (platform_optional_espocrm_assistant_enabled | bool) else [])
           }}
       tags: [always]
 

--- a/docs/optional-crm-apps.md
+++ b/docs/optional-crm-apps.md
@@ -140,8 +140,70 @@ platform_secrets:
   espocrm_admin_password: "CHANGE_ME"
 ```
 
-If external HTTPS validation is enabled, include the enabled host in
-`direct_http_urls` so the direct-origin exposure check covers it too.
+### EspoCRM Assistant
+
+The EspoCRM assistant is disabled by default and requires EspoCRM itself to be
+enabled. Turning on `platform_optional_apps.espocrm_assistant.enabled` does not
+turn on `platform_optional_apps.espocrm.enabled`; the production playbook fails
+early if the assistant is enabled without EspoCRM.
+
+When enabled, the assistant runs in the `espocrm` namespace as an internal
+Kubernetes service. It exposes a streamable HTTP MCP endpoint at `/mcp` for the
+future OAuth-capable MCP gateway, and a separate approval service on port
+`8090`. Neither endpoint should be internet-exposed directly.
+
+Required GitOps settings:
+
+```yaml
+platform_optional_apps:
+  espocrm:
+    enabled: true
+  espocrm_assistant:
+    enabled: true
+```
+
+Required assistant secrets:
+
+```yaml
+platform_secrets:
+  espocrm_assistant_read_api_key: "CHANGE_ME"
+  espocrm_assistant_read_secret_key: ""
+  espocrm_assistant_write_api_key: "CHANGE_ME"
+  espocrm_assistant_write_secret_key: ""
+  espocrm_assistant_token: "CHANGE_ME"
+  espocrm_assistant_apply_token: "CHANGE_ME"
+```
+
+Use separate EspoCRM API users for read and write access. The read API user is
+used by assistant-visible MCP tools. The write API user is used only by the
+human-approved apply endpoint. The `*_secret_key` values are optional HMAC
+secrets if HMAC is enabled for the corresponding EspoCRM API user. The
+assistant token protects internal non-mutating JSON helper routes. The apply
+token protects `/approval/apply-change` and should be shared only with the
+approved executor path.
+
+The assistant source, tests, Dockerfile, release workflow, and service-specific
+developer documentation live in the dedicated service repository:
+`https://github.com/The-Keep-Studios/espocrm-assistant`.
+
+TKP consumes the published service image by immutable digest:
+
+```text
+ghcr.io/the-keep-studios/espocrm-assistant@sha256:aea7326a6df729feb94595740040aba184274d0f897fdd4ffcc5d8408df3e585
+```
+
+That digest was resolved from public tag `sha-7235661`, built from service
+commit `72356613fccb406af4d7511e45af68cb7acedf0f`. Future assistant service
+releases should update only the digest and any changed operator contract in TKP.
+Do not reintroduce the service source, tests, package metadata, Dockerfile, or
+service release workflow into this repository.
+
+For local service commands, streamable HTTP configuration, approval endpoint
+examples, and the build-vs-wrap MCP evaluation, see the service repository.
+
+If external HTTPS validation is enabled, include the enabled public CRM host in
+`direct_http_urls` so the direct-origin exposure check covers it too. The
+EspoCRM assistant has no public hostname and should not be added here.
 
 ```yaml
 direct_http_urls:

--- a/kubernetes/apps/espocrm-assistant/deployment.yaml
+++ b/kubernetes/apps/espocrm-assistant/deployment.yaml
@@ -1,0 +1,181 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: espocrm-assistant
+  namespace: espocrm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: espocrm-assistant
+  template:
+    metadata:
+      labels:
+        app: espocrm-assistant
+    spec:
+      securityContext:
+        fsGroup: 65532
+      containers:
+      - name: mcp
+        image: ghcr.io/the-keep-studios/espocrm-assistant@sha256:aea7326a6df729feb94595740040aba184274d0f897fdd4ffcc5d8408df3e585
+        imagePullPolicy: IfNotPresent
+        command:
+        - thekeep-espocrm-mcp-http
+        env:
+        - name: ESPOCRM_URL
+          value: http://espocrm.espocrm.svc.cluster.local
+        - name: ESPOCRM_ALLOW_HTTP
+          value: "1"
+        - name: ESPOCRM_READ_AUTH_METHOD
+          value: apikey
+        - name: ESPOCRM_READ_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-assistant-secrets
+              key: ESPOCRM_READ_API_KEY
+        - name: ESPOCRM_READ_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-assistant-secrets
+              key: ESPOCRM_READ_SECRET_KEY
+              optional: true
+        - name: ESPOCRM_MCP_HOST
+          value: 0.0.0.0
+        - name: ESPOCRM_MCP_PORT
+          value: "8080"
+        - name: ESPOCRM_MCP_PATH
+          value: /mcp
+        - name: ESPOCRM_MCP_STATELESS_HTTP
+          value: "1"
+        ports:
+        - name: mcp
+          containerPort: 8080
+        readinessProbe:
+          tcpSocket:
+            port: mcp
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 6
+        livenessProbe:
+          tcpSocket:
+            port: mcp
+          periodSeconds: 30
+          timeoutSeconds: 3
+          failureThreshold: 4
+        resources:
+          requests:
+            cpu: 25m
+            memory: 96Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi
+      - name: approval
+        image: ghcr.io/the-keep-studios/espocrm-assistant@sha256:aea7326a6df729feb94595740040aba184274d0f897fdd4ffcc5d8408df3e585
+        imagePullPolicy: IfNotPresent
+        command:
+        - thekeep-espocrm-http
+        env:
+        - name: ESPOCRM_URL
+          value: http://espocrm.espocrm.svc.cluster.local
+        - name: ESPOCRM_ALLOW_HTTP
+          value: "1"
+        - name: ESPOCRM_READ_AUTH_METHOD
+          value: apikey
+        - name: ESPOCRM_READ_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-assistant-secrets
+              key: ESPOCRM_READ_API_KEY
+        - name: ESPOCRM_READ_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-assistant-secrets
+              key: ESPOCRM_READ_SECRET_KEY
+              optional: true
+        - name: ESPOCRM_WRITE_AUTH_METHOD
+          value: apikey
+        - name: ESPOCRM_WRITE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-assistant-secrets
+              key: ESPOCRM_WRITE_API_KEY
+        - name: ESPOCRM_WRITE_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-assistant-secrets
+              key: ESPOCRM_WRITE_SECRET_KEY
+              optional: true
+        - name: ESPOCRM_ASSISTANT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-assistant-secrets
+              key: ESPOCRM_ASSISTANT_TOKEN
+        - name: ESPOCRM_ASSISTANT_APPLY_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: espocrm-assistant-secrets
+              key: ESPOCRM_ASSISTANT_APPLY_TOKEN
+        - name: ESPOCRM_ASSISTANT_PORT
+          value: "8090"
+        - name: ESPOCRM_ASSISTANT_AUDIT_LOG
+          value: /var/lib/thekeep/espocrm-assistant/audit.jsonl
+        ports:
+        - name: approval
+          containerPort: 8090
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: approval
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 6
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: approval
+          periodSeconds: 30
+          timeoutSeconds: 3
+          failureThreshold: 4
+        volumeMounts:
+        - name: audit-log
+          mountPath: /var/lib/thekeep/espocrm-assistant
+        resources:
+          requests:
+            cpu: 25m
+            memory: 96Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi
+      volumes:
+      - name: audit-log
+        persistentVolumeClaim:
+          claimName: espocrm-assistant-audit
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: espocrm-assistant
+  namespace: espocrm
+spec:
+  type: ClusterIP
+  selector:
+    app: espocrm-assistant
+  ports:
+  - name: mcp
+    port: 8080
+    targetPort: mcp
+  - name: approval
+    port: 8090
+    targetPort: approval
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: espocrm-assistant-audit
+  namespace: espocrm
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/espocrm-assistant/kustomization.yaml
+++ b/kubernetes/apps/espocrm-assistant/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml

--- a/kubernetes/gitops/templates/platform-applications.yaml
+++ b/kubernetes/gitops/templates/platform-applications.yaml
@@ -88,6 +88,30 @@ spec:
     - CreateNamespace=true
     - ServerSideApply=true
 {% endif %}
+{% if ((platform_optional_apps | default({})).espocrm_assistant | default({})).enabled | default(false) | bool %}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: platform-crm-espocrm-assistant
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: "{{ gitops_repo_url }}"
+    targetRevision: "{{ gitops_revision }}"
+    path: kubernetes/apps/espocrm-assistant
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: espocrm
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true
+{% endif %}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application


### PR DESCRIPTION
## Summary
- Add the TKP GitOps integration for the extracted EspoCRM assistant service image.
- Pin the Kubernetes workload to the public immutable OCI digest `ghcr.io/the-keep-studios/espocrm-assistant@sha256:aea7326a6df729feb94595740040aba184274d0f897fdd4ffcc5d8408df3e585`.
- Add the optional app toggle, assistant secret creation, and production guard so the assistant requires EspoCRM but does not enable EspoCRM by side effect.
- Document the service repository boundary and the operator configuration/secrets path.

## Boundary
- No assistant source, tests, package metadata, Dockerfile, or service image workflow are added to TKP.
- No `imagePullSecrets` or registry credentials are required; the image is consumed from the public package by digest.
- The assistant is internal-only via ClusterIP and has no ingress or public hostname.

## Evidence
- Anonymous OCI registry check for tag `sha-7235661` returned HTTP 200 and digest `sha256:aea7326a6df729feb94595740040aba184274d0f897fdd4ffcc5d8408df3e585`.
- `scripts/test-iac-static.sh`
- `kubectl kustomize kubernetes/apps/espocrm-assistant`
- Focused Ansible check rejects `platform_optional_apps.espocrm_assistant.enabled: true` when `platform_optional_apps.espocrm.enabled: false`.

Refs #66.
Supersedes #52.