### PR TITLE
Add low-noise quality and secret gates

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -48,6 +48,16 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Go for actionlint
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Install actionlint
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+          echo "${HOME}/go/bin" >> "${GITHUB_PATH}"
+
       - name: Install Ansible
         run: python -m pip install ansible-core==2.16.3
 
@@ -57,4 +67,6 @@ jobs:
           version: v1.33.0
 
       - name: Run quality checks
+        env:
+          QUALITY_REQUIRE_ACTIONLINT: "true"
         run: scripts/test-quality.sh

--- a/README.md
+++ b/README.md
@@ -232,7 +232,22 @@ The first enforced baseline reuses `scripts/test-iac-static.sh`, which already c
 QUALITY_STRICT=true scripts/test-quality.sh
 ```
 
-Use the strict mode to evaluate `shellcheck`, `shfmt`, `actionlint`, `yamllint`, `ruff`, and `hadolint` without turning noisy or branch-specific tools into a default PR blocker too early.
+The default gate also runs `scripts/check-secrets.sh`, a lightweight secret exposure scan for high-confidence private key blocks, common token prefixes, kubeconfig private keys, and private installation config filenames such as `ansible/production_vars.yml`, `ansible/inventory.production.ini`, and `scripts/production.env`.
+
+GitHub Actions linting is promoted as the first traditional external linter. CI installs `actionlint` and runs `scripts/test-quality.sh` with `QUALITY_REQUIRE_ACTIONLINT=true`; local runs use `actionlint` when it is installed and otherwise report a skip.
+
+Use strict mode to keep evaluating `shellcheck`, `shfmt`, `yamllint`, `ruff`, and `hadolint` without turning noisy or branch-specific tools into a default PR blocker too early.
+
+Current quality-gate decisions:
+
+| Check | Default status | Reason |
+| --- | --- | --- |
+| Secret exposure scan | Enforced locally and in CI | High-confidence patterns only; no broad allowlist that could normalize real secrets. |
+| `actionlint` | Enforced in CI; local when installed | One workflow, low-noise validation, no source rewrites required. |
+| Kustomize render and Ansible syntax | Enforced | Existing static IaC baseline with useful signal. |
+| `kubeconform` / `kubeval` | Opportunistic when installed | Useful schema check, but CRDs and remote bases still need scoped handling before requiring it everywhere. |
+| `shellcheck`, `shfmt`, `yamllint`, `ansible-lint` | Strict/evaluation only | Keep out of the default gate until their noise profile is reduced without broad style rewrites. |
+| `ruff`, `hadolint` | Deferred until matching files exist | No tracked Python service files or container build files on `main` yet. |
 
 ## Operations Runbook
 

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+cd "${PROJECT_ROOT}"
+
+failures=0
+
+log() {
+  printf '\n== %s ==\n' "$*"
+}
+
+record_failure() {
+  failures=1
+  printf '%s\n' "$*" >&2
+}
+
+is_binary() {
+  ! LC_ALL=C grep -Iq . "$1"
+}
+
+scan_file() {
+  local file="$1"
+  local pattern="$2"
+  local description="$3"
+  local matches
+
+  if is_binary "${file}"; then
+    return
+  fi
+
+  matches="$(LC_ALL=C grep -n -E -- "${pattern}" "${file}" || true)"
+  if [ -n "${matches}" ]; then
+    record_failure "possible secret exposure: ${description} in ${file}"
+    printf '%s\n' "${matches}" >&2
+  fi
+}
+
+check_private_path() {
+  local file="$1"
+
+  case "${file}" in
+    ansible/production_vars.yml|ansible/inventory.production.ini|scripts/production.env)
+      record_failure "private installation config is tracked or staged: ${file}"
+      ;;
+    *.kubeconfig|*/kubeconfig|kubeconfig|*.pem|*.key|*id_rsa|*id_ed25519|*id_ecdsa)
+      record_failure "high-risk credential filename is tracked or staged: ${file}"
+      ;;
+  esac
+}
+
+log "Secret exposure scan"
+
+while IFS= read -r file; do
+  [ -f "${file}" ] || continue
+
+  check_private_path "${file}"
+  scan_file "${file}" '-----BEGIN ((RSA|DSA|EC|OPENSSH|PGP) )?PRIVATE KEY( BLOCK)?-----' "private key block"
+  scan_file "${file}" '(^|[^A-Za-z0-9_])ghp_[A-Za-z0-9_]{36,}' "GitHub classic token"
+  scan_file "${file}" 'github_pat_[A-Za-z0-9_]{20,}' "GitHub fine-grained token"
+  scan_file "${file}" 'xox[baprs]-[A-Za-z0-9-]{20,}' "Slack token"
+  scan_file "${file}" 'AKIA[0-9A-Z]{16}' "AWS access key id"
+  scan_file "${file}" 'AIza[0-9A-Za-z_-]{35}' "Google API key"
+  scan_file "${file}" '(^|[^A-Za-z0-9_-])sk-[A-Za-z0-9_-]{32,}' "OpenAI-style API key"
+  scan_file "${file}" '^[[:space:]]*client-key-data:[[:space:]]*[^#[:space:]]+' "kubeconfig client private key"
+done < <(git ls-files --cached --others --exclude-standard | sort -u)
+
+if [ "${failures}" -ne 0 ]; then
+  printf '\nSecret exposure scan failed. Remove the secret or move private installation config to ignored local files.\n' >&2
+  exit 1
+fi
+
+echo "Secret exposure scan passed."

--- a/scripts/test-quality.sh
+++ b/scripts/test-quality.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "${SCRIPT_DIR}")"
 QUALITY_STRICT="${QUALITY_STRICT:-false}"
+QUALITY_REQUIRE_ACTIONLINT="${QUALITY_REQUIRE_ACTIONLINT:-false}"
 cd "${PROJECT_ROOT}"
 export ANSIBLE_STDOUT_CALLBACK="${ANSIBLE_STDOUT_CALLBACK:-default}"
 
@@ -21,6 +22,24 @@ count_repo_files() {
 
 command_available() {
   command -v "$1" >/dev/null 2>&1
+}
+
+run_actionlint() {
+  local workflow_files=()
+  mapfile -t workflow_files < <(repo_files '.github/workflows/*.yml' '.github/workflows/*.yaml')
+  if [ "${#workflow_files[@]}" -eq 0 ]; then
+    echo "skip actionlint: no GitHub workflow files"
+    return
+  fi
+
+  if command_available actionlint; then
+    actionlint "${workflow_files[@]}"
+  elif [ "${QUALITY_REQUIRE_ACTIONLINT}" = "true" ]; then
+    echo "Missing required command: actionlint" >&2
+    exit 1
+  else
+    echo "skip actionlint: not installed"
+  fi
 }
 
 run_optional_linters() {
@@ -42,16 +61,6 @@ run_optional_linters() {
       shfmt -d "${shell_files[@]}"
     else
       echo "skip shfmt: not installed"
-    fi
-  fi
-
-  local workflow_files=()
-  mapfile -t workflow_files < <(repo_files '.github/workflows/*.yml' '.github/workflows/*.yaml')
-  if [ "${#workflow_files[@]}" -gt 0 ]; then
-    if command_available actionlint; then
-      actionlint "${workflow_files[@]}"
-    else
-      echo "skip actionlint: not installed"
     fi
   fi
 
@@ -95,6 +104,12 @@ printf 'python_files=%s\n' "$(count_repo_files '*.py')"
 printf 'container_build_files=%s\n' "$(count_repo_files 'Dockerfile' '**/Dockerfile' '*.Dockerfile' '*Dockerfile')"
 printf 'github_workflows=%s\n' "$(count_repo_files '.github/workflows/*.yml' '.github/workflows/*.yaml')"
 printf 'markdown_files=%s\n' "$(count_repo_files '*.md')"
+
+log "Lightweight secret scan"
+"${SCRIPT_DIR}/check-secrets.sh"
+
+log "GitHub Actions lint"
+run_actionlint
 
 log "Baseline static checks"
 "${SCRIPT_DIR}/test-iac-static.sh"


### PR DESCRIPTION
Refs #59
Closes #60
Refs #69

## Summary

- Add `scripts/check-secrets.sh` as a dependency-free, high-confidence secret exposure scan for private key blocks, common token prefixes, kubeconfig private keys, and ignored private installation config filenames.
- Run the secret scan from `scripts/test-quality.sh` by default.
- Promote `actionlint` as the first traditional external linter in CI by installing it in the quality workflow and requiring it through `QUALITY_REQUIRE_ACTIONLINT=true`.
- Document the promoted checks and the strict-only/deferred tools in the README.

## Validation

- `scripts/check-secrets.sh` passed.
- `bash -n scripts/check-secrets.sh scripts/test-quality.sh` passed.
- `scripts/test-quality.sh` passed locally. Local output notes `actionlint` was skipped because it is not installed in this environment; the workflow installs `actionlint` and requires it in CI.
- `git diff --check` passed.
- GitHub Actions `Quality Checks / Quality` passed for commit `3370eb3`.

## Notes

This closes #60 after merge because the lightweight secret scanner and local/CI gate are implemented and documented.

This does not close #59. It is the first low-noise strict-quality slice: secret scanning and workflow lint are promoted, while shellcheck, shfmt, yamllint, ansible-lint, and stricter Kubernetes schema checks remain evaluation/strict-mode work until their noise profile is reduced without broad style rewrites.
