### PR TITLE
[codex] Sanitize production inventory examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ The Ansible controller does not need to be the k3s control-plane host. The produ
 
 ```ini
 [k3s_control_plane]
-framework-desktop ansible_host=192.168.0.46 ansible_user=iantsmall
+k3s-control-plane ansible_host=192.0.2.10 ansible_user=platform-admin
 
 [k3s_control_plane:vars]
 ansible_connection=ssh

--- a/ansible/inventory.production.ini.example
+++ b/ansible/inventory.production.ini.example
@@ -1,6 +1,6 @@
 [k3s_control_plane]
 # Example:
-# framework13 ansible_host=192.168.1.50 ansible_user=iantsmall
+# k3s-control-plane ansible_host=192.0.2.10 ansible_user=platform-admin
 
 [k3s_control_plane:vars]
 ansible_connection=ssh


### PR DESCRIPTION
Closes #78
Refs #77

## Summary

- Replace the README production inventory example with documentation-reserved host values.
- Replace the tracked inventory example comment with documentation-reserved host values.
- Leave ignored local production inventory/vars files untouched.

## Safety

- Documentation-only change.
- No production deployment performed.
- No release tag created.
- No secrets, credentials, private hostnames, private paths, or production commands added.

## Validation

- `git diff --check`
- `scripts/test-iac-static.sh`
- `scripts/test-quality.sh`
- Targeted scan for the prior local machine/IP/user values in touched files returned no matches.