### PR TITLE
[codex] Add DMARC app instance example

### DIFF
--- a/examples/app-instances.example.json
+++ b/examples/app-instances.example.json
@@ -49,6 +49,38 @@
         "schedule": "29 3 * * *",
         "retention": "14d"
       }
+    },
+    {
+      "app_type": "dmarc-monitor",
+      "instance_name": "example-client-dmarc",
+      "namespace": "example-client-dmarc",
+      "hostname": "dmarc.example-client.invalid",
+      "access_policy": "internal-authenticated",
+      "exposure": {
+        "public_ingress": true,
+        "cloudflare_tunnel_route": true
+      },
+      "storage": {
+        "pvc_prefix": "example-client-dmarc",
+        "database_binding": "example-client-dmarc-db"
+      },
+      "secrets": {
+        "mailbox_secret_ref": "example-client-dmarc-mailbox-secret",
+        "report_ingestion_secret_ref": "example-client-dmarc-report-ingestion-secret",
+        "oidc_secret_ref": "example-client-dmarc-oidc-secret"
+      },
+      "report_ingestion": {
+        "aggregate_reports_only": true,
+        "forensic_reports_enabled": false,
+        "private_domain_config_required": true,
+        "raw_report_storage": "example-client-dmarc-raw-reports",
+        "dns_mutation_allowed": false
+      },
+      "backups": {
+        "enabled": true,
+        "schedule": "43 3 * * *",
+        "retention": "90d"
+      }
     }
   ]
 }


### PR DESCRIPTION
Refs #67
Refs #72

## Summary

- Add a fake DMARC monitoring app-instance example as a real consumer of the app-instance model from #72.
- Define mailbox/report-ingestion secret refs, authenticated access policy, storage/database binding, aggregate-only ingestion, no DNS mutation, and backup retention expectations.

## Safety

- Fake `.invalid` hostname and fake secret names only.
- No real domains, mailbox credentials, report data, DNS changes, deployment, production mutation, or release tag.
- Does not select or deploy a DMARC monitoring implementation.

## Validation

- `python3 scripts/test-app-instance-examples.py`
- `scripts/test-quality.sh`
- `git diff --check`

## Notes

This proves the #72 app-instance shape can represent #67. #67 remains open because tool evaluation, deployment shape, retention policy documentation, and operational smoke checks are not complete.