### PR TITLE
[codex] Build lead triage automation loop

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -50,15 +50,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Set up Go for actionlint
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.23"
-
       - name: Install actionlint
         run: |
-          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
-          echo "${HOME}/go/bin" >> "${GITHUB_PATH}"
+          mkdir -p "${HOME}/.local/bin"
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz" \
+            | tar -xz -C "${HOME}/.local/bin" actionlint
+          chmod +x "${HOME}/.local/bin/actionlint"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
 
       - name: Install Ansible
         run: python -m pip install ansible-core==2.16.3

--- a/README.md
+++ b/README.md
@@ -297,25 +297,26 @@ Before opening an app-support PR, include relevant evidence:
 
 ### Local Automation Fixture
 
-`scripts/run-automation-fixture.py` is the first local-only automation scaffold
-for #15 and #28. It reads fake job-source data from
-`examples/automation-job-source.fixture.json` and emits deterministic Markdown
-with source attribution, lead/opportunity classification, recommended CRM
-action, summary, next action, and an approval-required marker. The current fake
-intake workflow covers a job lead, recruiter email, and application
-confirmation. The default provider is fake and requires no hosted API key, no
-network access, and no real Gmail, EspoCRM, Leantime, client, or production
-data.
+`scripts/run-automation-fixture.py` runs the local fake lead-triage automation
+loop for #15 and #28. It reads fake job/client intake data from
+`examples/automation-job-source.fixture.json`, prints a deterministic Markdown
+triage report, and can write machine-readable dry-run JSON. The workflow covers
+a job lead, recruiter email, ATS confirmation, consulting/client inquiry, and
+poor-fit rejection. It performs no network calls, uses no secrets, reads no real
+Gmail/EspoCRM/Leantime data, and writes no CRM records.
 
 ```bash
 python3 scripts/run-automation-fixture.py \
-  --fixture examples/automation-job-source.fixture.json
+  --fixture examples/automation-job-source.fixture.json \
+  --json-output .artifacts/automation-triage.dry-run.json
 ```
 
 Use `--provider local-auto` to detect supported local model CLIs without making
 model calls. If no local provider command is present, the runner reports the
 skip and still uses the deterministic fake provider. Use `--self-test` to verify
-that fixtures with missing required fields fail validation.
+that malformed fixtures fail, missing fields are surfaced, rejected items do not
+produce CRM payloads, and Opportunity candidates require reciprocal signal or
+explicit override.
 
 ### TODO Tracking Standard
 

--- a/README.md
+++ b/README.md
@@ -300,9 +300,12 @@ Before opening an app-support PR, include relevant evidence:
 `scripts/run-automation-fixture.py` is the first local-only automation scaffold
 for #15 and #28. It reads fake job-source data from
 `examples/automation-job-source.fixture.json` and emits deterministic Markdown
-with source, classification, summary, next action, and an approval-needed
-marker. The default provider is fake and requires no hosted API key, no network
-access, and no real Gmail, EspoCRM, Leantime, client, or production data.
+with source attribution, lead/opportunity classification, recommended CRM
+action, summary, next action, and an approval-required marker. The current fake
+intake workflow covers a job lead, recruiter email, and application
+confirmation. The default provider is fake and requires no hosted API key, no
+network access, and no real Gmail, EspoCRM, Leantime, client, or production
+data.
 
 ```bash
 python3 scripts/run-automation-fixture.py \

--- a/examples/automation-job-source.fixture.json
+++ b/examples/automation-job-source.fixture.json
@@ -23,7 +23,11 @@
         "automation",
         "platform"
       ],
-      "risk_flags": []
+      "risk_flags": [],
+      "details": {
+        "remote_policy": "remote",
+        "fit_reason": "Strong match for platform automation and Linux operations."
+      }
     },
     {
       "item_id": "fake-job-002",
@@ -40,7 +44,11 @@
         "human_reply",
         "consulting"
       ],
-      "risk_flags": []
+      "risk_flags": [],
+      "details": {
+        "reciprocal_signal_detail": "Recruiter asked for availability and next-step preferences.",
+        "expected_next_step": "Reply with availability after human review."
+      }
     },
     {
       "item_id": "fake-job-003",
@@ -55,7 +63,49 @@
         "application_confirmation",
         "automated"
       ],
-      "risk_flags": []
+      "risk_flags": [],
+      "details": {
+        "application_reference": "fake-application-001"
+      }
+    },
+    {
+      "item_id": "fake-client-001",
+      "source_kind": "client_inquiry",
+      "source": "example-consulting-inquiry",
+      "received_at": "2026-06-07T16:20:00Z",
+      "company": "Example Advisory Co",
+      "role": "Internal Automation Assessment",
+      "description": "Founder asked about help mapping manual operations into a small self-hosted automation workflow.",
+      "contact": "founder@example.test",
+      "signals": [
+        "inbound_inquiry",
+        "consulting",
+        "automation"
+      ],
+      "risk_flags": [],
+      "details": {
+        "decision_maker": "founder"
+      }
+    },
+    {
+      "item_id": "fake-job-004",
+      "source_kind": "job_lead",
+      "source": "example-community-board",
+      "received_at": "2026-06-08T09:05:00Z",
+      "company": "Example Retail Group",
+      "role": "Onsite Helpdesk Analyst",
+      "description": "Local onsite support role with no automation scope and no remote option.",
+      "contact": "ops@example.test",
+      "signals": [
+        "operations"
+      ],
+      "risk_flags": [
+        "onsite_only",
+        "low_fit"
+      ],
+      "details": {
+        "fit_reason": "Poor fit: onsite-only support role without platform automation scope."
+      }
     }
   ]
 }

--- a/examples/automation-job-source.fixture.json
+++ b/examples/automation-job-source.fixture.json
@@ -11,6 +11,7 @@
   "items": [
     {
       "item_id": "fake-job-001",
+      "source_kind": "job_lead",
       "source": "example-job-board",
       "received_at": "2026-06-04T10:30:00Z",
       "company": "Example Robotics",
@@ -26,6 +27,7 @@
     },
     {
       "item_id": "fake-job-002",
+      "source_kind": "recruiter_email",
       "source": "example-recruiter-email",
       "received_at": "2026-06-05T14:45:00Z",
       "company": "Example Systems",
@@ -42,19 +44,18 @@
     },
     {
       "item_id": "fake-job-003",
-      "source": "example-community-board",
+      "source_kind": "application_confirmation",
+      "source": "example-ats-email",
       "received_at": "2026-06-06T08:10:00Z",
-      "company": "Example Retail Group",
-      "role": "Onsite Helpdesk Analyst",
-      "description": "Local onsite support role with no automation scope and no remote option.",
-      "contact": "ops@example.test",
+      "company": "Example Robotics",
+      "role": "Platform Automation Engineer",
+      "description": "Automated application confirmation for the fake Platform Automation Engineer application.",
+      "contact": "no-reply@ats.example.test",
       "signals": [
-        "operations"
+        "application_confirmation",
+        "automated"
       ],
-      "risk_flags": [
-        "onsite_only",
-        "low_fit"
-      ]
+      "risk_flags": []
     }
   ]
 }

--- a/scripts/run-automation-fixture.py
+++ b/scripts/run-automation-fixture.py
@@ -24,6 +24,7 @@ REQUIRED_TOP_LEVEL = {
 }
 REQUIRED_ITEM_FIELDS = {
     "item_id",
+    "source_kind",
     "source",
     "received_at",
     "company",
@@ -32,6 +33,14 @@ REQUIRED_ITEM_FIELDS = {
     "contact",
     "signals",
     "risk_flags",
+}
+REQUIRED_SOURCE_KINDS = {
+    "application_confirmation",
+    "job_lead",
+    "recruiter_email",
+}
+ALLOWED_SOURCE_KINDS = REQUIRED_SOURCE_KINDS | {
+    "community_board",
 }
 BANNED_FIXTURE_MARKERS = {
     "gmail.com",
@@ -59,13 +68,17 @@ class ProviderStatus:
 @dataclass(frozen=True)
 class AutomationResult:
     item_id: str
+    source_kind: str
     source: str
     company: str
     role: str
-    classification: str
+    triage: str
+    crm_classification: str
+    recommended_crm_action: str
     summary: str
     next_action: str
-    approval_needed: bool
+    approval_required: bool
+    source_attribution: str
 
 
 def fail(message: str) -> None:
@@ -172,6 +185,7 @@ def validate_fixture(data: dict[str, Any]) -> None:
         fail("items must be a non-empty list.")
 
     seen_ids: set[str] = set()
+    seen_source_kinds: set[str] = set()
     for index, raw_item in enumerate(items):
         item = require_mapping(raw_item, f"items[{index}]")
         missing_item = sorted(REQUIRED_ITEM_FIELDS - set(item))
@@ -181,6 +195,10 @@ def validate_fixture(data: dict[str, Any]) -> None:
         if item_id in seen_ids:
             fail(f"items[{index}].item_id must be unique: {item_id}")
         seen_ids.add(item_id)
+        source_kind = require_string(item["source_kind"], f"items[{index}].source_kind")
+        if source_kind not in ALLOWED_SOURCE_KINDS:
+            fail(f"items[{index}].source_kind is unsupported: {source_kind}")
+        seen_source_kinds.add(source_kind)
         for field in ("source", "received_at", "company", "role", "description"):
             require_string(item[field], f"items[{index}].{field}")
         contact = require_string(item["contact"], f"items[{index}].contact")
@@ -189,6 +207,10 @@ def validate_fixture(data: dict[str, Any]) -> None:
             fail(f"items[{index}].contact must use example.test: {contact}")
         require_string_list(item["signals"], f"items[{index}].signals")
         require_string_list(item["risk_flags"], f"items[{index}].risk_flags")
+
+    missing_source_kinds = sorted(REQUIRED_SOURCE_KINDS - seen_source_kinds)
+    if missing_source_kinds:
+        fail(f"Fixture is missing required fake intake inputs: {', '.join(missing_source_kinds)}")
 
 
 def provider_status(mode: str) -> ProviderStatus:
@@ -213,30 +235,47 @@ def provider_status(mode: str) -> ProviderStatus:
     )
 
 
-def classify_item(item: dict[str, Any]) -> tuple[str, str, bool]:
+def classify_item(item: dict[str, Any]) -> tuple[str, str, str, str, bool]:
+    source_kind = require_string(item["source_kind"], "source_kind")
     signals = set(require_string_list(item["signals"], "signals"))
     risk_flags = set(require_string_list(item["risk_flags"], "risk_flags"))
 
     if {"onsite_only", "low_fit"} & risk_flags:
         return (
             "reject",
+            "lead",
+            "no_crm_write",
             "Do not pursue; keep only the read-only fixture summary.",
             False,
+        )
+    if source_kind == "application_confirmation":
+        return (
+            "confirmation",
+            "lead",
+            "update_lead_application_confirmed",
+            "Update the matching Lead with confirmation evidence after approval.",
+            True,
         )
     if "human_reply" in signals:
         return (
             "opportunity_candidate",
+            "opportunity_candidate",
+            "prepare_opportunity_after_approval",
             "Prepare follow-up questions and require human approval before any outreach or CRM write.",
             True,
         )
     if "remote" in signals and ({"automation", "platform", "consulting"} & signals):
         return (
             "priority_lead",
+            "lead",
+            "create_priority_lead",
             "Draft a tailored application packet for human review.",
             True,
         )
     return (
         "lead",
+        "lead",
+        "create_lead",
         "Add to the review queue and wait for human prioritization.",
         True,
     )
@@ -245,21 +284,35 @@ def classify_item(item: dict[str, Any]) -> tuple[str, str, bool]:
 def run_automation(data: dict[str, Any]) -> list[AutomationResult]:
     results: list[AutomationResult] = []
     for item in data["items"]:
-        classification, next_action, approval_needed = classify_item(item)
+        (
+            triage,
+            crm_classification,
+            recommended_crm_action,
+            next_action,
+            approval_required,
+        ) = classify_item(item)
         summary = (
             f"{item['company']} - {item['role']}: "
             f"{item['description']}"
         )
+        source_attribution = (
+            f"{item['source_kind']} from {item['source']} received "
+            f"{item['received_at']} via {item['contact']}"
+        )
         results.append(
             AutomationResult(
                 item_id=item["item_id"],
+                source_kind=item["source_kind"],
                 source=item["source"],
                 company=item["company"],
                 role=item["role"],
-                classification=classification,
+                triage=triage,
+                crm_classification=crm_classification,
+                recommended_crm_action=recommended_crm_action,
                 summary=summary,
                 next_action=next_action,
-                approval_needed=approval_needed,
+                approval_required=approval_required,
+                source_attribution=source_attribution,
             )
         )
     return results
@@ -283,18 +336,22 @@ def render_markdown(
     ]
 
     for result in results:
-        approval = "yes" if result.approval_needed else "no"
+        approval = "yes" if result.approval_required else "no"
         lines.extend(
             [
                 f"## {result.item_id}",
                 "",
+                f"- Source kind: {result.source_kind}",
                 f"- Source: {result.source}",
+                f"- Source attribution: {result.source_attribution}",
                 f"- Company: {result.company}",
                 f"- Role: {result.role}",
-                f"- Classification: {result.classification}",
+                f"- Triage: {result.triage}",
+                f"- Lead vs opportunity: {result.crm_classification}",
+                f"- Recommended CRM action: {result.recommended_crm_action}",
+                f"- Approval required: {approval}",
                 f"- Summary: {result.summary}",
                 f"- Next action: {result.next_action}",
-                f"- Approval needed: {approval}",
                 "",
             ]
         )

--- a/scripts/run-automation-fixture.py
+++ b/scripts/run-automation-fixture.py
@@ -36,6 +36,7 @@ REQUIRED_ITEM_FIELDS = {
 }
 REQUIRED_SOURCE_KINDS = {
     "application_confirmation",
+    "client_inquiry",
     "job_lead",
     "recruiter_email",
 }
@@ -53,6 +54,14 @@ BANNED_FIXTURE_MARKERS = {
     "CHANGE_ME",
     "REPLACE_ME",
 }
+DETAIL_REQUIREMENTS_BY_SOURCE_KIND = {
+    "application_confirmation": ["application_reference"],
+    "client_inquiry": ["budget_range", "timeline", "decision_maker"],
+    "job_lead": ["remote_policy"],
+    "recruiter_email": ["reciprocal_signal_detail"],
+}
+REJECT_RISK_FLAGS = {"onsite_only", "low_fit", "spam", "outside_scope"}
+RECIPROCAL_SIGNALS = {"human_reply", "inbound_inquiry", "interview_request", "warm_intro"}
 
 
 class FixtureError(ValueError):
@@ -72,13 +81,17 @@ class AutomationResult:
     source: str
     company: str
     role: str
-    triage: str
+    recommendation: str
+    recommendation_slug: str
     crm_classification: str
     recommended_crm_action: str
     summary: str
     next_action: str
     approval_required: bool
     source_attribution: str
+    audit_note: str
+    missing_fields: tuple[str, ...]
+    dry_run_change_set: dict[str, Any] | None
 
 
 def fail(message: str) -> None:
@@ -109,6 +122,12 @@ def require_string_list(value: Any, context: str) -> list[str]:
     for index, item in enumerate(value):
         strings.append(require_string(item, f"{context}[{index}]"))
     return strings
+
+
+def require_optional_details(item: dict[str, Any], context: str) -> dict[str, Any]:
+    if "details" not in item:
+        return {}
+    return require_mapping(item["details"], f"{context}.details")
 
 
 def walk_strings(value: Any) -> list[str]:
@@ -207,6 +226,12 @@ def validate_fixture(data: dict[str, Any]) -> None:
             fail(f"items[{index}].contact must use example.test: {contact}")
         require_string_list(item["signals"], f"items[{index}].signals")
         require_string_list(item["risk_flags"], f"items[{index}].risk_flags")
+        details = require_optional_details(item, f"items[{index}]")
+        for key, value in details.items():
+            require_string(str(key), f"items[{index}].details key")
+            if isinstance(value, bool):
+                continue
+            require_string(value, f"items[{index}].details.{key}")
 
     missing_source_kinds = sorted(REQUIRED_SOURCE_KINDS - seen_source_kinds)
     if missing_source_kinds:
@@ -235,13 +260,40 @@ def provider_status(mode: str) -> ProviderStatus:
     )
 
 
-def classify_item(item: dict[str, Any]) -> tuple[str, str, str, str, bool]:
+def item_details(item: dict[str, Any]) -> dict[str, Any]:
+    return require_mapping(item.get("details", {}), "details")
+
+
+def missing_fields_for_item(item: dict[str, Any]) -> tuple[str, ...]:
+    risk_flags = set(require_string_list(item["risk_flags"], "risk_flags"))
+    if REJECT_RISK_FLAGS & risk_flags:
+        return ()
+    details = item_details(item)
+    required_details = DETAIL_REQUIREMENTS_BY_SOURCE_KIND.get(item["source_kind"], [])
+    missing = [
+        f"details.{field}"
+        for field in required_details
+        if not str(details.get(field, "")).strip()
+    ]
+    return tuple(missing)
+
+
+def has_reciprocal_signal(item: dict[str, Any]) -> bool:
+    details = item_details(item)
+    signals = set(require_string_list(item["signals"], "signals"))
+    explicit_override = details.get("explicit_opportunity_override") is True
+    return bool(signals & RECIPROCAL_SIGNALS) or explicit_override
+
+
+def classify_item(item: dict[str, Any]) -> tuple[str, str, str, str, str, bool]:
     source_kind = require_string(item["source_kind"], "source_kind")
     signals = set(require_string_list(item["signals"], "signals"))
     risk_flags = set(require_string_list(item["risk_flags"], "risk_flags"))
+    missing_fields = missing_fields_for_item(item)
 
-    if {"onsite_only", "low_fit"} & risk_flags:
+    if REJECT_RISK_FLAGS & risk_flags:
         return (
+            "Reject",
             "reject",
             "lead",
             "no_crm_write",
@@ -250,42 +302,158 @@ def classify_item(item: dict[str, Any]) -> tuple[str, str, str, str, bool]:
         )
     if source_kind == "application_confirmation":
         return (
-            "confirmation",
+            "Lead",
+            "lead",
             "lead",
             "update_lead_application_confirmed",
             "Update the matching Lead with confirmation evidence after approval.",
             True,
         )
-    if "human_reply" in signals:
+    if source_kind == "client_inquiry" and missing_fields:
         return (
+            "Needs more info",
+            "needs_more_info",
+            "lead",
+            "create_lead_and_clarification_task",
+            "Ask for the missing consulting intake details before treating this as an Opportunity.",
+            True,
+        )
+    if has_reciprocal_signal(item):
+        return (
+            "Opportunity candidate",
             "opportunity_candidate",
             "opportunity_candidate",
             "prepare_opportunity_after_approval",
-            "Prepare follow-up questions and require human approval before any outreach or CRM write.",
+            "Prepare follow-up and require human approval before any outreach or CRM write.",
             True,
         )
     if "remote" in signals and ({"automation", "platform", "consulting"} & signals):
         return (
-            "priority_lead",
+            "Lead",
+            "lead",
             "lead",
             "create_priority_lead",
             "Draft a tailored application packet for human review.",
             True,
         )
     return (
+        "Needs more info",
+        "needs_more_info",
         "lead",
-        "lead",
-        "create_lead",
-        "Add to the review queue and wait for human prioritization.",
+        "create_lead_and_clarification_task",
+        "Add to the review queue and clarify missing fit or next-step details.",
         True,
     )
+
+
+def build_lead_fields(item: dict[str, Any], status: str) -> dict[str, str]:
+    return {
+        "name": f"{item['role']} - {item['company']}",
+        "accountName": item["company"],
+        "emailAddress": item["contact"],
+        "title": item["role"],
+        "status": status,
+        "source": item["source"],
+        "description": item["description"],
+    }
+
+
+def build_dry_run_change_set(
+    item: dict[str, Any],
+    recommendation_slug: str,
+    recommended_crm_action: str,
+    approval_required: bool,
+    source_attribution: str,
+    audit_note: str,
+    missing_fields: tuple[str, ...],
+) -> dict[str, Any] | None:
+    if recommendation_slug == "reject":
+        return None
+
+    changes: list[dict[str, Any]] = []
+    if recommended_crm_action == "update_lead_application_confirmed":
+        changes.append(
+            {
+                "change_id": f"{item['item_id']}-lead-confirmation",
+                "action": "update",
+                "entity": "Lead",
+                "match": {
+                    "company": item["company"],
+                    "role": item["role"],
+                },
+                "fields": {
+                    "status": "In Process",
+                    "description": (
+                        f"{item['description']}\n\n"
+                        f"Application confirmation source: {source_attribution}"
+                    ),
+                },
+            }
+        )
+    elif recommendation_slug == "opportunity_candidate":
+        changes.append(
+            {
+                "change_id": f"{item['item_id']}-opportunity",
+                "action": "create",
+                "entity": "Opportunity",
+                "fields": {
+                    "name": f"{item['role']} - {item['company']}",
+                    "accountName": item["company"],
+                    "stage": "Qualification",
+                    "probability": "25",
+                    "description": (
+                        f"{item['description']}\n\n"
+                        f"Reciprocal signal present. Source: {source_attribution}"
+                    ),
+                },
+            }
+        )
+    else:
+        status = "New" if recommendation_slug == "lead" else "Assigned"
+        changes.append(
+            {
+                "change_id": f"{item['item_id']}-lead",
+                "action": "create",
+                "entity": "Lead",
+                "fields": build_lead_fields(item, status),
+            }
+        )
+
+    if missing_fields:
+        changes.append(
+            {
+                "change_id": f"{item['item_id']}-clarification-task",
+                "action": "create",
+                "entity": "Task",
+                "fields": {
+                    "name": f"Clarify intake details for {item['company']}",
+                    "status": "Not Started",
+                    "priority": "Normal",
+                    "parentType": "Lead",
+                    "parentName": f"{item['role']} - {item['company']}",
+                    "description": f"Missing fields: {', '.join(missing_fields)}",
+                },
+            }
+        )
+
+    return {
+        "change_set_id": f"dryrun-{item['item_id']}",
+        "source_item_id": item["item_id"],
+        "dry_run": True,
+        "approval_required": approval_required,
+        "write_performed": False,
+        "source_attribution": source_attribution,
+        "audit_note": audit_note,
+        "changes": changes,
+    }
 
 
 def run_automation(data: dict[str, Any]) -> list[AutomationResult]:
     results: list[AutomationResult] = []
     for item in data["items"]:
         (
-            triage,
+            recommendation,
+            recommendation_slug,
             crm_classification,
             recommended_crm_action,
             next_action,
@@ -299,6 +467,20 @@ def run_automation(data: dict[str, Any]) -> list[AutomationResult]:
             f"{item['source_kind']} from {item['source']} received "
             f"{item['received_at']} via {item['contact']}"
         )
+        missing_fields = missing_fields_for_item(item)
+        audit_note = (
+            "Assistant-originated dry run; no CRM write performed. "
+            f"Source item {item['item_id']} attributed to {source_attribution}."
+        )
+        dry_run_change_set = build_dry_run_change_set(
+            item,
+            recommendation_slug,
+            recommended_crm_action,
+            approval_required,
+            source_attribution,
+            audit_note,
+            missing_fields,
+        )
         results.append(
             AutomationResult(
                 item_id=item["item_id"],
@@ -306,13 +488,17 @@ def run_automation(data: dict[str, Any]) -> list[AutomationResult]:
                 source=item["source"],
                 company=item["company"],
                 role=item["role"],
-                triage=triage,
+                recommendation=recommendation,
+                recommendation_slug=recommendation_slug,
                 crm_classification=crm_classification,
                 recommended_crm_action=recommended_crm_action,
                 summary=summary,
                 next_action=next_action,
                 approval_required=approval_required,
                 source_attribution=source_attribution,
+                audit_note=audit_note,
+                missing_fields=missing_fields,
+                dry_run_change_set=dry_run_change_set,
             )
         )
     return results
@@ -337,6 +523,12 @@ def render_markdown(
 
     for result in results:
         approval = "yes" if result.approval_required else "no"
+        missing = ", ".join(result.missing_fields) if result.missing_fields else "none"
+        change_set = (
+            result.dry_run_change_set["change_set_id"]
+            if result.dry_run_change_set is not None
+            else "none"
+        )
         lines.extend(
             [
                 f"## {result.item_id}",
@@ -346,10 +538,13 @@ def render_markdown(
                 f"- Source attribution: {result.source_attribution}",
                 f"- Company: {result.company}",
                 f"- Role: {result.role}",
-                f"- Triage: {result.triage}",
+                f"- Recommendation: {result.recommendation}",
                 f"- Lead vs opportunity: {result.crm_classification}",
                 f"- Recommended CRM action: {result.recommended_crm_action}",
                 f"- Approval required: {approval}",
+                f"- Missing fields: {missing}",
+                f"- Dry-run change set: {change_set}",
+                f"- Audit note: {result.audit_note}",
                 f"- Summary: {result.summary}",
                 f"- Next action: {result.next_action}",
                 "",
@@ -358,14 +553,91 @@ def render_markdown(
     return "\n".join(lines).rstrip() + "\n"
 
 
+def render_dry_run_json(
+    fixture: dict[str, Any],
+    results: list[AutomationResult],
+    provider: ProviderStatus,
+) -> dict[str, Any]:
+    return {
+        "fixture_source": fixture["source_name"],
+        "provider": provider.name,
+        "network_calls_by_default": False,
+        "write_performed": False,
+        "items": [
+            {
+                "item_id": result.item_id,
+                "source_kind": result.source_kind,
+                "source": result.source,
+                "company": result.company,
+                "role": result.role,
+                "recommendation": result.recommendation,
+                "recommendation_slug": result.recommendation_slug,
+                "crm_classification": result.crm_classification,
+                "recommended_crm_action": result.recommended_crm_action,
+                "approval_required": result.approval_required,
+                "missing_fields": list(result.missing_fields),
+                "source_attribution": result.source_attribution,
+                "audit_note": result.audit_note,
+                "dry_run_change_set_id": (
+                    result.dry_run_change_set["change_set_id"]
+                    if result.dry_run_change_set is not None
+                    else None
+                ),
+            }
+            for result in results
+        ],
+        "dry_run_change_sets": [
+            result.dry_run_change_set
+            for result in results
+            if result.dry_run_change_set is not None
+        ],
+    }
+
+
 def run_self_test(valid_data: dict[str, Any]) -> None:
     missing_field = copy.deepcopy(valid_data)
     del missing_field["items"][0]["role"]
     try:
         validate_fixture(missing_field)
     except FixtureError:
-        return
-    fail("Self-test failed: fixture with missing required item field passed.")
+        pass
+    else:
+        fail("Self-test failed: fixture with missing required item field passed.")
+
+    missing_required_kind = copy.deepcopy(valid_data)
+    missing_required_kind["items"] = [
+        item
+        for item in missing_required_kind["items"]
+        if item["source_kind"] != "client_inquiry"
+    ]
+    try:
+        validate_fixture(missing_required_kind)
+    except FixtureError:
+        pass
+    else:
+        fail("Self-test failed: fixture missing client inquiry input passed.")
+
+    no_reciprocal = copy.deepcopy(valid_data)
+    for item in no_reciprocal["items"]:
+        if item["source_kind"] == "recruiter_email":
+            item["signals"] = ["remote", "automation"]
+            item["details"].pop("reciprocal_signal_detail", None)
+            recommendation = classify_item(item)[1]
+            if recommendation == "opportunity_candidate":
+                fail("Self-test failed: Opportunity candidate did not require reciprocal signal.")
+
+    provider = provider_status("fake")
+    results = run_automation(valid_data)
+    dry_run = render_dry_run_json(valid_data, results, provider)
+    rejected = [item for item in dry_run["items"] if item["recommendation_slug"] == "reject"]
+    if not rejected:
+        fail("Self-test failed: no rejected fixture item was exercised.")
+    if any(item["dry_run_change_set_id"] is not None for item in rejected):
+        fail("Self-test failed: rejected fixture generated a CRM payload.")
+    if not dry_run["dry_run_change_sets"]:
+        fail("Self-test failed: no dry-run CRM change sets were generated.")
+    if not any(item["missing_fields"] for item in dry_run["items"]):
+        fail("Self-test failed: missing fields were not surfaced.")
 
 
 def parse_args() -> argparse.Namespace:
@@ -388,6 +660,11 @@ def parse_args() -> argparse.Namespace:
         help="Optional Markdown output path. Defaults to stdout.",
     )
     parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Optional machine-readable dry-run JSON output path.",
+    )
+    parser.add_argument(
         "--self-test",
         action="store_true",
         help="Also verify that a fixture missing required fields fails validation.",
@@ -403,12 +680,21 @@ def main() -> None:
         if args.self_test:
             run_self_test(fixture)
         provider = provider_status(args.provider)
-        markdown = render_markdown(fixture, run_automation(fixture), provider)
+        results = run_automation(fixture)
+        markdown = render_markdown(fixture, results, provider)
+        dry_run_json = render_dry_run_json(fixture, results, provider)
     except FixtureError as exc:
         print(str(exc), file=sys.stderr)
         raise SystemExit(1) from exc
 
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(
+            json.dumps(dry_run_json, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
     if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(markdown, encoding="utf-8")
     else:
         print(markdown, end="")

--- a/scripts/test-quality.sh
+++ b/scripts/test-quality.sh
@@ -119,9 +119,13 @@ log "App-instance example checks"
 python3 "${SCRIPT_DIR}/test-app-instance-examples.py"
 
 log "Local automation fixture checks"
+automation_json="$(mktemp "${TMPDIR:-/tmp}/thekeep-automation.XXXXXX.json")"
+trap 'rm -f "${automation_json}"' EXIT
 python3 "${SCRIPT_DIR}/run-automation-fixture.py" \
   --fixture "${PROJECT_ROOT}/examples/automation-job-source.fixture.json" \
+  --json-output "${automation_json}" \
   --self-test >/dev/null
+python3 -m json.tool "${automation_json}" >/dev/null
 
 log "EspoCRM assistant contract checks"
 python3 "${SCRIPT_DIR}/test-espocrm-assistant-contract.py"

--- a/scripts/test-quality.sh
+++ b/scripts/test-quality.sh
@@ -118,6 +118,11 @@ log "Baseline static checks"
 log "App-instance example checks"
 python3 "${SCRIPT_DIR}/test-app-instance-examples.py"
 
+log "Local automation fixture checks"
+python3 "${SCRIPT_DIR}/run-automation-fixture.py" \
+  --fixture "${PROJECT_ROOT}/examples/automation-job-source.fixture.json" \
+  --self-test >/dev/null
+
 log "EspoCRM assistant contract checks"
 python3 "${SCRIPT_DIR}/test-espocrm-assistant-contract.py"
 


### PR DESCRIPTION
Refs #28
Refs #15

## Summary

- Build one local fake lead-triage automation loop around job/client intake.
- Cover fake job lead, recruiter email, ATS confirmation, consulting/client inquiry, and poor-fit rejection inputs.
- Produce deterministic Markdown with recommendation, CRM action, source attribution, missing fields, approval requirement, audit note, and dry-run change-set ID.
- Write machine-readable dry-run JSON with item decisions and EspoCRM-shaped dry-run change sets for Lead-worthy items.
- Enforce malformed-fixture failures, required fake input coverage, rejected-item no-payload behavior, missing-field surfacing, and reciprocal-signal requirements for Opportunity candidates through `--self-test` and `scripts/test-quality.sh`.

## Safety

- Fake fixture data only.
- No secrets, hosted API keys, network calls by default, Gmail access, EspoCRM credentials, real job-search data, private hostnames, browser automation, CRM writes, production deploy, or release tag.
- #28 remains open because this is a fake local dry-run workflow, not real EspoCRM UAT.

## How to run

```bash
python3 scripts/run-automation-fixture.py \
  --fixture examples/automation-job-source.fixture.json \
  --json-output .artifacts/automation-triage.dry-run.json
```

## Validation

- `python3 -m py_compile scripts/run-automation-fixture.py`
- `python3 scripts/run-automation-fixture.py --fixture examples/automation-job-source.fixture.json --json-output .artifacts/automation-triage-test/dry-run.json`
- `python3 scripts/run-automation-fixture.py --fixture examples/automation-job-source.fixture.json --self-test --json-output /tmp/thekeep-automation-selftest.json`
- `python3 -m json.tool .artifacts/automation-triage-test/dry-run.json`
- `scripts/test-quality.sh`
- `git diff --check`