### PR TITLE
[codex] Add lead triage source export adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,14 @@ python3 scripts/run-automation-fixture.py \
   --json-output .artifacts/automation-triage.dry-run.json
 ```
 
+To run the same workflow from a fake redacted source export:
+
+```bash
+python3 scripts/run-automation-fixture.py \
+  --source-export examples/lead-triage-source-export.fixture.json \
+  --json-output .artifacts/automation-source-export.dry-run.json
+```
+
 Use `--provider local-auto` to detect supported local model CLIs without making
 model calls. If no local provider command is present, the runner reports the
 skip and still uses the deterministic fake provider. Use `--self-test` to verify

--- a/examples/lead-triage-source-export.fixture.json
+++ b/examples/lead-triage-source-export.fixture.json
@@ -1,0 +1,115 @@
+{
+  "export_version": "2026-07-01.fake.v1",
+  "source_system": "redacted-mailbox-json",
+  "fixture_only": true,
+  "records": [
+    {
+      "source_record_id": "export-msg-001",
+      "source_kind": "job_lead",
+      "source_name": "example-job-alert",
+      "received_at": "2026-06-10T10:30:00Z",
+      "sender": "jobs@example.test",
+      "subject": "Platform Automation Engineer at Example Robotics",
+      "company": "Example Robotics",
+      "role": "Platform Automation Engineer",
+      "body_excerpt": "Remote role focused on self-hosted workflow automation, Linux operations, and internal platform reliability.",
+      "source_url": "https://jobs.example.invalid/postings/fake-job-001",
+      "signals": [
+        "remote",
+        "automation",
+        "platform"
+      ],
+      "risk_flags": [],
+      "details": {
+        "remote_policy": "remote",
+        "fit_reason": "Strong match for platform automation and Linux operations."
+      }
+    },
+    {
+      "source_record_id": "export-msg-002",
+      "source_kind": "recruiter_email",
+      "source_name": "example-recruiter-mailbox",
+      "received_at": "2026-06-11T14:45:00Z",
+      "sender": "recruiter@example.test",
+      "subject": "Fractional AI operations conversation",
+      "company": "Example Systems",
+      "role": "Fractional AI Operations Lead",
+      "body_excerpt": "Recruiter asked for availability to discuss a part-time internal automation and AI operations engagement.",
+      "source_url": "https://mail.example.invalid/messages/export-msg-002",
+      "signals": [
+        "remote",
+        "automation",
+        "human_reply",
+        "consulting"
+      ],
+      "risk_flags": [],
+      "details": {
+        "reciprocal_signal_detail": "Recruiter asked for availability and next-step preferences.",
+        "expected_next_step": "Reply with availability after human review."
+      }
+    },
+    {
+      "source_record_id": "export-msg-003",
+      "source_kind": "application_confirmation",
+      "source_name": "example-ats-mailbox",
+      "received_at": "2026-06-12T08:10:00Z",
+      "sender": "no-reply@ats.example.test",
+      "subject": "Application received for Platform Automation Engineer",
+      "company": "Example Robotics",
+      "role": "Platform Automation Engineer",
+      "body_excerpt": "Automated application confirmation for the fake Platform Automation Engineer application.",
+      "source_url": "https://mail.example.invalid/messages/export-msg-003",
+      "signals": [
+        "application_confirmation",
+        "automated"
+      ],
+      "risk_flags": [],
+      "details": {
+        "application_reference": "fake-application-001"
+      }
+    },
+    {
+      "source_record_id": "export-msg-004",
+      "source_kind": "client_inquiry",
+      "source_name": "example-consulting-mailbox",
+      "received_at": "2026-06-13T16:20:00Z",
+      "sender": "founder@example.test",
+      "subject": "Automation assessment inquiry",
+      "company": "Example Advisory Co",
+      "role": "Internal Automation Assessment",
+      "body_excerpt": "Founder asked about help mapping manual operations into a small self-hosted automation workflow.",
+      "source_url": "https://mail.example.invalid/messages/export-msg-004",
+      "signals": [
+        "inbound_inquiry",
+        "consulting",
+        "automation"
+      ],
+      "risk_flags": [],
+      "details": {
+        "decision_maker": "founder"
+      }
+    },
+    {
+      "source_record_id": "export-msg-005",
+      "source_kind": "job_lead",
+      "source_name": "example-community-board",
+      "received_at": "2026-06-14T09:05:00Z",
+      "sender": "ops@example.test",
+      "subject": "Onsite Helpdesk Analyst",
+      "company": "Example Retail Group",
+      "role": "Onsite Helpdesk Analyst",
+      "body_excerpt": "Local onsite support role with no automation scope and no remote option.",
+      "source_url": "https://jobs.example.invalid/postings/fake-job-005",
+      "signals": [
+        "operations"
+      ],
+      "risk_flags": [
+        "onsite_only",
+        "low_fit"
+      ],
+      "details": {
+        "fit_reason": "Poor fit: onsite-only support role without platform automation scope."
+      }
+    }
+  ]
+}

--- a/scripts/run-automation-fixture.py
+++ b/scripts/run-automation-fixture.py
@@ -12,6 +12,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -62,6 +63,26 @@ DETAIL_REQUIREMENTS_BY_SOURCE_KIND = {
 }
 REJECT_RISK_FLAGS = {"onsite_only", "low_fit", "spam", "outside_scope"}
 RECIPROCAL_SIGNALS = {"human_reply", "inbound_inquiry", "interview_request", "warm_intro"}
+SOURCE_EXPORT_REQUIRED_TOP_LEVEL = {
+    "export_version",
+    "source_system",
+    "fixture_only",
+    "records",
+}
+SOURCE_EXPORT_REQUIRED_RECORD_FIELDS = {
+    "source_record_id",
+    "source_kind",
+    "source_name",
+    "received_at",
+    "sender",
+    "subject",
+    "company",
+    "role",
+    "body_excerpt",
+    "signals",
+    "risk_flags",
+}
+ALLOWED_SOURCE_EXPORT_SYSTEMS = {"redacted-mailbox-json"}
 
 
 class FixtureError(ValueError):
@@ -150,7 +171,11 @@ def validate_no_private_fixture_values(data: dict[str, Any]) -> None:
     for value in walk_strings(data):
         lower_value = value.lower()
         if "http://" in lower_value or "https://" in lower_value:
-            fail(f"Fixture must not contain service URLs: {value}")
+            parsed = urlparse(value)
+            if parsed.scheme != "https":
+                fail(f"Fixture URLs must use https: {value}")
+            if parsed.hostname is None or not parsed.hostname.endswith(".example.invalid"):
+                fail(f"Fixture URLs must use fake .example.invalid hosts: {value}")
         if re.search(r"\b(10|172\.(1[6-9]|2[0-9]|3[0-1])|192\.168)\.", value):
             fail(f"Fixture contains a private network address: {value}")
         for banned in BANNED_FIXTURE_MARKERS:
@@ -166,6 +191,139 @@ def load_fixture(path: Path) -> dict[str, Any]:
     except json.JSONDecodeError as exc:
         fail(f"{path} is not valid JSON: {exc}")
     return require_mapping(loaded, str(path))
+
+
+def load_source_export(path: Path) -> dict[str, Any]:
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        fail(f"Missing source export: {path}")
+    except json.JSONDecodeError as exc:
+        fail(f"{path} is not valid JSON: {exc}")
+    return require_mapping(loaded, str(path))
+
+
+def validate_source_export(data: dict[str, Any]) -> None:
+    missing = sorted(SOURCE_EXPORT_REQUIRED_TOP_LEVEL - set(data))
+    if missing:
+        fail(f"Source export is missing required fields: {', '.join(missing)}")
+    require_string(data.get("export_version"), "export_version")
+    source_system = require_string(data.get("source_system"), "source_system")
+    if source_system not in ALLOWED_SOURCE_EXPORT_SYSTEMS:
+        fail(f"Unsupported source export system: {source_system}")
+    require_bool(data.get("fixture_only"), True, "fixture_only")
+    validate_no_private_fixture_values(data)
+
+    records = data.get("records")
+    if not isinstance(records, list) or not records:
+        fail("records must be a non-empty list.")
+
+    seen_ids: set[str] = set()
+    seen_source_kinds: set[str] = set()
+    for index, raw_record in enumerate(records):
+        record = require_mapping(raw_record, f"records[{index}]")
+        missing_record = sorted(SOURCE_EXPORT_REQUIRED_RECORD_FIELDS - set(record))
+        if missing_record:
+            fail(f"records[{index}] is missing required fields: {', '.join(missing_record)}")
+        source_record_id = require_string(
+            record["source_record_id"],
+            f"records[{index}].source_record_id",
+        )
+        if source_record_id in seen_ids:
+            fail(f"records[{index}].source_record_id must be unique: {source_record_id}")
+        seen_ids.add(source_record_id)
+        source_kind = require_string(record["source_kind"], f"records[{index}].source_kind")
+        if source_kind not in ALLOWED_SOURCE_KINDS:
+            fail(f"records[{index}].source_kind is unsupported: {source_kind}")
+        seen_source_kinds.add(source_kind)
+        for field in (
+            "source_name",
+            "received_at",
+            "sender",
+            "subject",
+            "company",
+            "role",
+            "body_excerpt",
+        ):
+            require_string(record[field], f"records[{index}].{field}")
+        sender = require_string(record["sender"], f"records[{index}].sender")
+        sender_domain = sender.rsplit("@", 1)[-1]
+        if sender_domain != "example.test" and not sender_domain.endswith(".example.test"):
+            fail(f"records[{index}].sender must use example.test: {sender}")
+        if "source_url" in record:
+            require_string(record["source_url"], f"records[{index}].source_url")
+        require_string_list(record["signals"], f"records[{index}].signals")
+        require_string_list(record["risk_flags"], f"records[{index}].risk_flags")
+        details = require_optional_details(record, f"records[{index}]")
+        for key, value in details.items():
+            require_string(str(key), f"records[{index}].details key")
+            if isinstance(value, bool):
+                continue
+            require_string(value, f"records[{index}].details.{key}")
+
+    missing_source_kinds = sorted(REQUIRED_SOURCE_KINDS - seen_source_kinds)
+    if missing_source_kinds:
+        missing_names = ", ".join(missing_source_kinds)
+        fail(f"Source export is missing required fake intake records: {missing_names}")
+
+
+def normalize_duplicate_key(record: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        record["source_kind"].strip().lower(),
+        record["company"].strip().lower(),
+        record["role"].strip().lower(),
+    )
+
+
+def source_export_to_fixture(data: dict[str, Any]) -> dict[str, Any]:
+    validate_source_export(data)
+    duplicate_first_seen: dict[tuple[str, str, str], str] = {}
+    items: list[dict[str, Any]] = []
+
+    for raw_record in data["records"]:
+        record = require_mapping(raw_record, "records item")
+        details = dict(require_mapping(record.get("details", {}), "record.details"))
+        details["source_record_id"] = record["source_record_id"]
+        details["source_system"] = data["source_system"]
+        details["source_subject"] = record["subject"]
+        if "source_url" in record:
+            details["source_url"] = record["source_url"]
+
+        duplicate_key = normalize_duplicate_key(record)
+        possible_duplicate_of = duplicate_first_seen.get(duplicate_key)
+        if possible_duplicate_of:
+            details["possible_duplicate_of"] = possible_duplicate_of
+        else:
+            duplicate_first_seen[duplicate_key] = record["source_record_id"]
+
+        items.append(
+            {
+                "item_id": record["source_record_id"],
+                "source_kind": record["source_kind"],
+                "source": f"{data['source_system']}:{record['source_name']}",
+                "received_at": record["received_at"],
+                "company": record["company"],
+                "role": record["role"],
+                "description": record["body_excerpt"],
+                "contact": record["sender"],
+                "signals": record["signals"],
+                "risk_flags": record["risk_flags"],
+                "details": details,
+            }
+        )
+
+    return {
+        "fixture_version": data["export_version"],
+        "source_name": data["source_system"],
+        "provider_contract": {
+            "default_provider": "fake-deterministic",
+            "hosted_api_keys_required": False,
+            "network_calls_by_default": False,
+            "writes_allowed": False,
+            "approval_required_for_external_actions": True,
+        },
+        "items": items,
+    }
 
 
 def validate_provider_contract(data: dict[str, Any]) -> None:
@@ -315,7 +473,10 @@ def classify_item(item: dict[str, Any]) -> tuple[str, str, str, str, str, bool]:
             "needs_more_info",
             "lead",
             "create_lead_and_clarification_task",
-            "Ask for the missing consulting intake details before treating this as an Opportunity.",
+            (
+                "Ask for the missing consulting intake details before treating "
+                "this as an Opportunity."
+            ),
             True,
         )
     if has_reciprocal_signal(item):
@@ -463,10 +624,17 @@ def run_automation(data: dict[str, Any]) -> list[AutomationResult]:
             f"{item['company']} - {item['role']}: "
             f"{item['description']}"
         )
-        source_attribution = (
-            f"{item['source_kind']} from {item['source']} received "
-            f"{item['received_at']} via {item['contact']}"
-        )
+        details = item_details(item)
+        attribution_parts = [
+            f"{item['source_kind']} from {item['source']}",
+            f"received {item['received_at']}",
+            f"via {item['contact']}",
+        ]
+        if details.get("source_subject"):
+            attribution_parts.append(f"subject {details['source_subject']}")
+        if details.get("source_url"):
+            attribution_parts.append(f"url {details['source_url']}")
+        source_attribution = "; ".join(attribution_parts)
         missing_fields = missing_fields_for_item(item)
         audit_note = (
             "Assistant-originated dry run; no CRM write performed. "
@@ -640,6 +808,31 @@ def run_self_test(valid_data: dict[str, Any]) -> None:
         fail("Self-test failed: missing fields were not surfaced.")
 
 
+def run_source_export_self_test(valid_export: dict[str, Any]) -> None:
+    missing_field = copy.deepcopy(valid_export)
+    del missing_field["records"][0]["subject"]
+    try:
+        validate_source_export(missing_field)
+    except FixtureError:
+        pass
+    else:
+        fail("Self-test failed: source export missing required field passed.")
+
+    duplicate_source = copy.deepcopy(valid_export)
+    duplicate_record = copy.deepcopy(duplicate_source["records"][0])
+    duplicate_record["source_record_id"] = "export-msg-duplicate"
+    duplicate_record["source_name"] = "example-duplicate-job-alert"
+    duplicate_source["records"].append(duplicate_record)
+    converted = source_export_to_fixture(duplicate_source)
+    duplicates = [
+        item
+        for item in converted["items"]
+        if item.get("details", {}).get("possible_duplicate_of")
+    ]
+    if not duplicates:
+        fail("Self-test failed: duplicate-ish source record was not detected.")
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -647,6 +840,14 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=DEFAULT_FIXTURE,
         help="Path to a fake automation fixture JSON file.",
+    )
+    parser.add_argument(
+        "--source-export",
+        type=Path,
+        help=(
+            "Path to a fake redacted source export JSON file. "
+            "When set, it is adapted into the triage fixture model."
+        ),
     )
     parser.add_argument(
         "--provider",
@@ -675,7 +876,13 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     try:
-        fixture = load_fixture(args.fixture)
+        if args.source_export:
+            source_export = load_source_export(args.source_export)
+            if args.self_test:
+                run_source_export_self_test(source_export)
+            fixture = source_export_to_fixture(source_export)
+        else:
+            fixture = load_fixture(args.fixture)
         validate_fixture(fixture)
         if args.self_test:
             run_self_test(fixture)

--- a/scripts/test-quality.sh
+++ b/scripts/test-quality.sh
@@ -120,12 +120,18 @@ python3 "${SCRIPT_DIR}/test-app-instance-examples.py"
 
 log "Local automation fixture checks"
 automation_json="$(mktemp "${TMPDIR:-/tmp}/thekeep-automation.XXXXXX.json")"
-trap 'rm -f "${automation_json}"' EXIT
+source_export_json="$(mktemp "${TMPDIR:-/tmp}/thekeep-source-export.XXXXXX.json")"
+trap 'rm -f "${automation_json}" "${source_export_json}"' EXIT
 python3 "${SCRIPT_DIR}/run-automation-fixture.py" \
   --fixture "${PROJECT_ROOT}/examples/automation-job-source.fixture.json" \
   --json-output "${automation_json}" \
   --self-test >/dev/null
 python3 -m json.tool "${automation_json}" >/dev/null
+python3 "${SCRIPT_DIR}/run-automation-fixture.py" \
+  --source-export "${PROJECT_ROOT}/examples/lead-triage-source-export.fixture.json" \
+  --json-output "${source_export_json}" \
+  --self-test >/dev/null
+python3 -m json.tool "${source_export_json}" >/dev/null
 
 log "EspoCRM assistant contract checks"
 python3 "${SCRIPT_DIR}/test-espocrm-assistant-contract.py"


### PR DESCRIPTION
Refs #89
Refs #28
Refs #15

## Summary

- Add one bounded source export path: fake `redacted-mailbox-json` under `examples/lead-triage-source-export.fixture.json`.
- Teach `scripts/run-automation-fixture.py --source-export ...` to validate and adapt that export into the existing lead-triage input model.
- Preserve source attribution from source system, source name, subject, sender, received date, company, role, and fake `.example.invalid` source URL.
- Reuse the existing Markdown report and machine-readable dry-run JSON output, including EspoCRM-shaped dry-run change sets for actionable items.
- Extend self-test and `scripts/test-quality.sh` to cover malformed source exports, required record coverage, duplicate-ish source records, reciprocal-signal behavior, missing fields, rejected items, and JSON validity.
- Keep README guidance to the one new safe source-export command.

## Safety

- Fake fixture data only.
- No live Gmail API, browser automation, EspoCRM credentials, CRM writes, real job-search data, private hostnames, secrets, production deploy, or release tag.
- Source URLs are allowed only as HTTPS `.example.invalid` fixture values.

## How to run

```bash
python3 scripts/run-automation-fixture.py \
  --source-export examples/lead-triage-source-export.fixture.json \
  --json-output .artifacts/automation-source-export.dry-run.json
```

## Validation

- `python3 -m py_compile scripts/run-automation-fixture.py`
- `python3 scripts/run-automation-fixture.py --source-export examples/lead-triage-source-export.fixture.json --json-output .artifacts/lead-triage-source-export-test/dry-run.json`
- `python3 scripts/run-automation-fixture.py --source-export examples/lead-triage-source-export.fixture.json --self-test --json-output /tmp/thekeep-source-export-selftest.json`
- `python3 scripts/run-automation-fixture.py --source-export examples/lead-triage-source-export.fixture.json --provider local-auto --json-output /tmp/thekeep-source-export-local-auto.json`
- `python3 -m json.tool .artifacts/lead-triage-source-export-test/dry-run.json`
- `scripts/test-quality.sh`
- `git diff --check`